### PR TITLE
Fix the bug that executor can't be closed regularly

### DIFF
--- a/test/pipeline_test.go
+++ b/test/pipeline_test.go
@@ -109,6 +109,27 @@ func TestQueueSubmitWithFuncWhenQueueClosed(t *testing.T) {
 	assert.Equal(t, k.ErrorQueueClosed, err)
 }
 
+func TestQueueExecutorAutoStop(t *testing.T) {
+	c := k.NewConfig()
+	c.WithHandleFunc(handleFunc).WithWorkerNumber(2)
+	queue := k.NewFakeDelayingQueue(workqueue.NewSimpleQueue(nil))
+
+	pl := k.NewPipeline(queue, c)
+	assert.NotNil(t, pl)
+
+	var err error
+	for i := 0; i < 10; i++ {
+		err = pl.Submit(i)
+		assert.Nil(t, err)
+	}
+
+	time.Sleep(15 * time.Second)
+
+	assert.Equal(t, int64(1), pl.GetWorkerNumber())
+
+	pl.Stop()
+}
+
 func TestQueueSubmit_DelayingQueue(t *testing.T) {
 	c := k.NewConfig()
 	c.WithHandleFunc(handleFunc).WithWorkerNumber(2)


### PR DESCRIPTION
This bug doesn't affect usage, but it doesn't guarantee that the counters will be fine after the current startup worker is recycled.

Also added GetWorkerNumber method to get the number of currently running workers.