### PR TITLE
feat: upgrade to Go 1.23, fix concurrency defects, and optimize hot p…

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -6,8 +6,8 @@ jobs:
   test:
     strategy:
       matrix:
-        go-version: [1.19.x, 1.20.x, 1.21.x, 1.22.x]
-        os: [ubuntu-latest, macos-latest, windows-latest]
+        go-version: [1.23.x, 1.24.x, 1.25.x]
+        os: [ubuntu-latest, macos-15, windows-latest]
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/setup-go@v4
@@ -15,4 +15,4 @@ jobs:
           go-version: "${{ matrix.go-version }}"
       - uses: actions/checkout@v3
       - name: Test
-        run: go mod tidy && go test -v ./test/...
+        run: go mod tidy && go vet ./... && go test -race ./...

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,16 @@
+# Karta 项目 Agent 规范
+
+## 基准采样环境纪律（2026-08-15 批准，recurrence=3 污染事故提炼）
+
+本机（i5-12400F / Windows）性能基准采样必须遵守：
+
+1. **会话分离**：基准采样与 `-race`/全量测试分离到独立会话，间隔 ≥1 分钟；禁止在 `-race` 全量测试后立即采样（commit/调度压力残留导致系统性虚高 +15~100%）
+2. **前置检查**：采样前确认主机 CPU 占用 < 10%（`Get-Counter '\Processor(_Total)\% Processor Time'`）；背景负载期间采样无效
+3. **存疑裁决**：出现疑似回退时，用同会话交替 A/B（before→after→before→after）+ 反序探针裁决；以**未变更代码路径**的基准作为环境对照——对照项同步膨胀即为环境因素，非代码回归
+4. **统计要求**：关键对比用 `-count≥10` + `benchstat`（p 值与方差）；单次数字或高方差（>±15%）数据不得作为回退裁决依据
+
+## 已知平台事项
+
+- `lifecycle_test.go` 的 POSIX 信号测试位于 `lifecycle_unix_test.go`（`//go:build !windows`），Windows 下自动排除，无需 overlay
+- Windows 上 `go test -cpuprofile` 会遗留 `karta.test.exe`（已 gitignore `*.exe`），会话结束前清理
+- 基线/复测产物约定目录：`B:\Temp\opencode\karta-perf\{baseline,round1,round2,round3,reports}`

--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -22,14 +22,14 @@ Karta v2 is a complete rewrite using Go generics. The API surface has changed si
 
 ## Prerequisites
 
-- **Go 1.21 or later** (v1 required Go 1.19+)
+- **Go 1.23 or later** (v1 required Go 1.19+)
 - Update your `go.mod` to use the v2 module path
 
 Verify your Go version:
 
 ```bash
 go version
-# go1.21.0 or later
+# go1.23.0 or later
 ```
 
 ---
@@ -308,7 +308,7 @@ sched := scheduler.NewDelayScheduler()
 
 | # | Change | v1 | v2 |
 |---|--------|-----|-----|
-| 1 | Go version | 1.19+ | 1.21+ |
+| 1 | Go version | 1.19+ | 1.23+ |
 | 2 | Module path | `github.com/shengyanli1982/karta` | `github.com/shengyanli1982/karta/v2` |
 | 3 | Config | `NewConfig()` builder | Removed; functional options |
 | 4 | Handler type | `func(any) (any, error)` | `func(ctx, In) (Out, error)` |

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 
 # Karta
 
-Karta is a lightweight, type-safe task batch and asynchronous processing library for Go. Rewritten from the ground up using Go 1.21+ generics, it provides compile-time type safety for both input and output — no more `any` casts, no more runtime surprises.
+Karta is a lightweight, type-safe task batch and asynchronous processing library for Go. Rewritten from the ground up using Go 1.23+ generics, it provides compile-time type safety for both input and output — no more `any` casts, no more runtime surprises.
 
 The library offers two core components:
 
@@ -18,7 +18,7 @@ The library offers two core components:
 
 ## Features
 
-- **Go 1.21+ generics** — type-safe `Group[In, Out]` and `Pipeline[In, Out]`
+- **Go 1.23+ generics** — type-safe `Group[In, Out]` and `Pipeline[In, Out]`
 - **Result[T] and Future[T]** — explicit result handling with `Ok()`, `Unwrap()`, `Get(ctx)`, and `Then(fn)` chaining
 - **High-performance fast paths** — `Group.Map` uses a sequential fast path for small batches, eliminating goroutine overhead; `Future` uses lazy channel allocation and atomic checks to minimize allocations
 - **Middleware chain** — composable `Middleware[In, Out]` wrapping pattern (Recovery, Logging, Timeout, RateLimit, Retry, Metrics, Tracing)
@@ -33,7 +33,7 @@ The library offers two core components:
 go get github.com/shengyanli1982/karta/v2
 ```
 
-Requires Go 1.21 or later.
+Requires Go 1.23 or later.
 
 ## Quick Start
 
@@ -213,7 +213,7 @@ import "github.com/shengyanli1982/karta/v2/scheduler"
 | **Priority**        | `scheduler.NewPriorityScheduler()`            | Priority queue (lower number = higher priority)              |
 | **RateLimiting**    | `scheduler.NewRateLimitingScheduler(limiter)` | Token-bucket rate-limited queue                              |
 | **Timer**           | `scheduler.NewTimerScheduler()`               | Absolute deadline + relative delay scheduling                |
-| **Bounded**         | `scheduler.NewBoundedScheduler(capacity)`     | Bounded blocking queue with back-pressure                    |
+| **Bounded**         | `scheduler.NewBoundedScheduler(capacity)`     | Bounded blocking queue with back-pressure (may briefly block when full before returning ErrSchedulerFull) |
 | **Retry**           | `scheduler.NewRetryScheduler(policy)`         | Automatic retry with configurable policy                     |
 | **DLQ**             | `scheduler.NewDLQScheduler(maxRetries)`       | Dead-letter queue for failed tasks                           |
 | **Lease**           | `scheduler.NewLeaseScheduler(leaseTimeout)`   | Lease-based task ownership with auto-requeue                 |
@@ -270,21 +270,26 @@ The `Shutdown()` method is idempotent and respects the global timeout. Slow comp
 
 ## Performance
 
-Karta is optimized for high-throughput workloads with minimal allocation overhead. Benchmark results on Apple M1 Max (Go 1.21):
+Karta is optimized for high-throughput workloads with minimal allocation overhead. Benchmark results measured on i5-12400F / Windows / go1.25:
 
-| Benchmark                | ns/op | B/op | allocs/op |
-| ------------------------ | ----- | ---- | --------- |
-| `GroupMap` (100 items)   | ~570  | 2688 | 1         |
-| `PipelineSubmit`         | ~906  | 208  | 4         |
-| `FutureGet` (resolved)   | ~24   | 80   | 1         |
-| `FutureResolve`          | ~32   | 80   | 1         |
-| `MiddlewareChain` (3 MW) | ~1    | 0    | 0         |
-| `SimpleScheduler`        | ~196  | 0    | 0         |
+| Benchmark                                     | ns/op  | B/op  | allocs/op |
+| --------------------------------------------- | ------ | ----- | --------- |
+| `GroupMap` (100 items)                        | ~639   | 2688  | 1         |
+| `GroupMap_Parallel` (100 items)               | ~455   | 2688  | 1         |
+| `GroupMap_LargeBatch` (1000 items, 8 workers) | ~39100 | 24927 | 9         |
+| `PipelineSubmit`                              | ~1400  | 205   | 3         |
+| `PipelineSubmit_Parallel`                     | ~1900  | 207   | 3         |
+| `FutureGet` (resolved)                        | ~31    | 80    | 1         |
+| `FutureResolve`                               | ~45    | 80    | 1         |
+| `FutureThen`                                  | ~1190  | 295   | 5         |
+| `MiddlewareChain` (3 MW)                      | ~1.35  | 0     | 0         |
+| `SimpleScheduler`                             | ~114   | 0     | 0         |
 
 Key optimizations:
 - **Sequential fast path**: `Group.Map` bypasses goroutine scheduling for small batches (<128 items), achieving single-digit microsecond latencies.
 - **Lazy channel allocation**: `Future` only allocates a `done` channel when a `Get` caller actually blocks, saving allocations on resolved futures.
 - **sync.Pool reuse**: `TaskEnvelope` and pipeline work contexts are pooled, reducing per-task allocations.
+- **Hybrid wait for large batches**: `Group.Map`'s large-batch parallel path combines bounded spinning with blocking waits to balance tail latency against CPU overhead.
 
 Run `go test -bench=. -benchmem ./...` to verify on your hardware.
 

--- a/bench_test.go
+++ b/bench_test.go
@@ -117,3 +117,59 @@ func BenchmarkScheduler_SimpleScheduler(b *testing.B) {
 		}
 	})
 }
+
+// BenchmarkGroupMap_LargeBatch — Group.Map 大批量吞吐（1000 项, 8 workers，覆盖并发等待路径）
+func BenchmarkGroupMap_LargeBatch(b *testing.B) {
+	handler := Handler[int, int](func(ctx context.Context, input int) (int, error) {
+		return input * 2, nil
+	})
+	g := NewGroup[int, int](handler, WithGroupWorkers(8))
+	defer g.Stop()
+
+	inputs := make([]int, 1000)
+	for i := range inputs {
+		inputs[i] = i
+	}
+
+	b.ResetTimer()
+	b.ReportAllocs()
+	for i := 0; i < b.N; i++ {
+		_ = g.Map(context.Background(), inputs)
+	}
+}
+
+// BenchmarkPipelineSubmit_Parallel — Pipeline.Submit + Future.Get 并发版
+func BenchmarkPipelineSubmit_Parallel(b *testing.B) {
+	handler := Handler[int, int](func(ctx context.Context, input int) (int, error) {
+		return input * 2, nil
+	})
+	sched := NewSimpleScheduler(4096)
+	p := NewPipeline[int, int](handler, sched, WithPipelineWorkers(8))
+	defer p.Stop()
+
+	b.ResetTimer()
+	b.ReportAllocs()
+	b.RunParallel(func(pb *testing.PB) {
+		i := 0
+		for pb.Next() {
+			f, err := p.Submit(context.Background(), i)
+			if err != nil {
+				b.Fatalf("Submit error: %v", err)
+			}
+			_ = f.Get(context.Background())
+			i++
+		}
+	})
+}
+
+// BenchmarkFutureThen — Pending Future + 异步 goroutine Resolve + Then 回调开销
+func BenchmarkFutureThen(b *testing.B) {
+	b.ReportAllocs()
+	for i := 0; i < b.N; i++ {
+		f := NewPendingFuture[int]()
+		go f.Resolve(Result[int]{Value: i})
+		done := make(chan struct{})
+		f.Then(func(Result[int]) { close(done) })
+		<-done
+	}
+}

--- a/future.go
+++ b/future.go
@@ -6,35 +6,33 @@ import (
 	"sync/atomic"
 )
 
+// Future 状态字位定义：合并为单个 atomic.Uint32（替代原先的 claimed/resolved
+// 两个 atomic.Bool），将 NewResolvedFuture 的原子写从 2 次压缩为 1 次。
+const (
+	futureClaimed  uint32 = 1 << iota // Resolve 认领位：仅 CAS(0, futureClaimed) 成功者可写 result；NewResolvedFuture 直接置位
+	futureResolved                    // 结果可读位：该位的 Store 发生在 result 写入之后，与 Get 快速路径的 Load 构成 SeqCst fence
+)
+
 // Future 是异步结果容器 (ADR-004/005: Pipeline 使用)
 // 线程安全，支持 Get(ctx) 超时取消和 Then(fn) 链式回调
 //
 // 内存优化策略（对比原始实现）:
-//  - Get 添加 atomic 快速路径：已 resolved 时跳过 select 开销
-//  - Resolve 去掉 sync.Once，改为 atomic.CompareAndSwap（CAS）+ close(done) 替代
-//  - result 作为普通字段，通过 claimed/resolved 的 SeqCst atomic fence 保证可见性
-//    （resolved.Store 之前的写操作对 resolved.Load 之后的读操作可见）
-//  - done channel 延迟分配（lazy）：仅在 Get 慢路径确实需要阻塞时才分配，
-//    消除热路径（Resolve→Get 快速路径场景）中的 channel 分配
-//  - NewResolvedFuture 使用共享已关闭 channel（resolvedSentinel），消除每次分配
+//   - Get 添加 atomic 快速路径：已 resolved 时跳过 select 开销
+//   - Resolve 去掉 sync.Once，改为 atomic.CompareAndSwap（CAS）+ close(done) 替代
+//   - result 作为普通字段，通过 state 状态字的 SeqCst atomic fence 保证可见性
+//     （resolved 位的 Store 在 result 写入之后，与 Get 的 Load 构成同一变量上的
+//     fence：Store 之前的写操作对检测到 resolved 位后的读操作可见）
+//   - claimed/resolved 合并为单一 state 状态字（atomic.Uint32），
+//     NewResolvedFuture 仅需 1 次原子 Store，热路径少一次 SeqCst 写
+//   - done channel 延迟分配（lazy）：仅在 Get 慢路径确实需要阻塞时才分配，
+//     消除热路径（Resolve→Get 快速路径场景）中的 channel 分配
+//   - NewResolvedFuture 使用共享已关闭 channel（resolvedSentinel），消除每次分配
 type Future[T any] struct {
-	done      chan struct{}       // 延迟分配：nil 表示尚未有阻塞 Get；非 nil 时为等待通道
-	result    Result[T]           // 普通字段，受 resolved atomic fence 保护
-	resolved  atomic.Bool         // true 表示 result 已可读取（在写入 result 之后设置）
-	claimed   atomic.Bool         // CAS 守卫：仅一个 goroutine 能完成 Resolve（替代 sync.Once）
+	done      chan struct{} // 延迟分配：nil 表示尚未有阻塞 Get；非 nil 时为等待通道
+	result    Result[T]     // 普通字段，受 state 的 resolved 位 fence 保护
+	state     atomic.Uint32 // 状态字：futureClaimed|futureResolved 位组合（见上方常量注释）
 	mu        sync.Mutex
 	callbacks []func(Result[T])
-}
-
-// doneChanPool 预留的 done channel 池。
-// 当前设计下 Resolve 不归还已关闭 channel（避免 sync.Pool.Put 引入额外分配），
-// 但在未来 sync.Pool 实现优化后可启用归还逻辑以复用 channel。
-// 使用指针 *chan struct{} 放入 pool，避免 interface 装箱导致的额外分配。
-var doneChanPool = sync.Pool{
-	New: func() any {
-		ch := make(chan struct{})
-		return &ch
-	},
 }
 
 // resolvedSentinel 是全局已关闭 channel，被 NewResolvedFuture 共享，
@@ -54,19 +52,21 @@ func NewPendingFuture[T any]() *Future[T] {
 
 // NewResolvedFuture 创建已完成的 Future。
 // 使用 shared resolvedSentinel（已关闭 channel），无需每次分配。
+// 单次原子 Store 同时置位 claimed|resolved：该 Future 已持有结果，
+// 后续 Resolve 的 CAS(0, futureClaimed) 必然失败，禁止覆写已读值。
 func NewResolvedFuture[T any](r Result[T]) *Future[T] {
 	f := &Future[T]{
 		done:   resolvedSentinel,
 		result: r,
 	}
-	f.resolved.Store(true)
+	f.state.Store(futureClaimed | futureResolved)
 	return f
 }
 
 // Get 阻塞等待结果，支持 context 取消/超时
 func (f *Future[T]) Get(ctx context.Context) Result[T] {
-	// 快速路径：已 resolved，直接返回（跳过 select 开销）
-	if f.resolved.Load() {
+	// 快速路径：resolved 位已置，直接返回（跳过 select 开销）
+	if f.state.Load()&futureResolved != 0 {
 		return f.result
 	}
 	// 慢路径：确保 done channel 存在（延迟分配）
@@ -76,7 +76,7 @@ func (f *Future[T]) Get(ctx context.Context) Result[T] {
 		// 此时直接返回以避免无谓的 channel 分配。
 		// 注意：此检查与 Resolve 的锁互斥，保证不会有另一个 goroutine
 		// 同时对同一 channel 执行 close（消除 double-close 竞态）。
-		if f.resolved.Load() {
+		if f.state.Load()&futureResolved != 0 {
 			f.mu.Unlock()
 			return f.result
 		}
@@ -96,17 +96,19 @@ func (f *Future[T]) Get(ctx context.Context) Result[T] {
 // Resolve 设置结果并通知所有等待者（仅第一次生效）
 // 使用 CAS 替代 sync.Once，减少分配和锁竞争
 func (f *Future[T]) Resolve(r Result[T]) {
-	if !f.claimed.CompareAndSwap(false, true) {
-		return // 已被其他 goroutine resolve，忽略
+	if !f.state.CompareAndSwap(0, futureClaimed) {
+		return // 已被其他 goroutine resolve，或由 NewResolvedFuture 构造（state≠0），忽略
 	}
-	// 严格顺序：先写入 result，再设置 resolved=true（SeqCst atomic fence 保证可见性）
+	// 严格顺序：先写入 result，再置 resolved 位。
+	// state.Store 与 Get 快速路径的 state.Load 构成同一变量上的 SeqCst fence：
+	// result 的写入（Store 之前）对检测到 resolved 位后的读取可见。
 	f.result = r
-	f.resolved.Store(true)
+	f.state.Store(futureClaimed | futureResolved)
 
 	// 持有锁期间关闭 done（若有 goroutine 正在等待）。
-	// 与 Get 的锁互斥保证：若 Get 持有锁时检测到 resolved=true，则直接返回
+	// 与 Get 的锁互斥保证：若 Get 持有锁时检测到 resolved 位，则直接返回
 	// （不分配/不关闭 channel），因此 Resolve 在此处看到的 f.done 若不为 nil，
-	// 则一定是未关闭的（仅由 Get 慢路径在 resolved=false 时分配）。
+	// 则一定是未关闭的（仅由 Get 慢路径在 resolved 位未置时分配）。
 	f.mu.Lock()
 	if f.done != nil {
 		close(f.done) // close 是并发安全的广播机制：所有 <-f.done 阻塞的 goroutine 都将解除
@@ -124,7 +126,7 @@ func (f *Future[T]) Resolve(r Result[T]) {
 // 如果 Future 已 resolve，回调立即在独立 goroutine 中执行
 func (f *Future[T]) Then(fn func(Result[T])) *Future[T] {
 	f.mu.Lock()
-	if f.resolved.Load() {
+	if f.state.Load()&futureResolved != 0 {
 		r := f.result
 		f.mu.Unlock()
 		go fn(r)

--- a/future_test.go
+++ b/future_test.go
@@ -2,6 +2,7 @@ package karta
 
 import (
 	"context"
+	"errors"
 	"sync"
 	"sync/atomic"
 	"testing"
@@ -102,5 +103,38 @@ func TestFuture_ConcurrentGet(t *testing.T) {
 	for i, r := range results {
 		require.True(t, r.Ok(), "goroutine %d", i)
 		assert.Equal(t, 42, r.Value, "goroutine %d", i)
+	}
+}
+
+// TestNewResolvedFuture_ResolveIgnored — P2 #14: NewResolvedFuture 构造时
+// claimed=true，后续 Resolve 不得覆写已读结果
+func TestNewResolvedFuture_ResolveIgnored(t *testing.T) {
+	f := NewResolvedFuture[int](Result[int]{Value: 1})
+	f.Resolve(Result[int]{Value: 2})
+	f.Resolve(Result[int]{Err: errors.New("overwrite")})
+
+	r := f.Get(context.Background())
+	assert.Equal(t, 1, r.Value, "结果应保持构造值")
+	assert.NoError(t, r.Err)
+}
+
+// TestNewResolvedFuture_ConcurrentGetResolve — -race 下并发 Get + Resolve 干净，
+// 且结果始终为构造值
+func TestNewResolvedFuture_ConcurrentGetResolve(t *testing.T) {
+	for round := range 100 {
+		f := NewResolvedFuture[int](Result[int]{Value: 42})
+		var wg sync.WaitGroup
+		wg.Add(2)
+		go func() {
+			defer wg.Done()
+			f.Resolve(Result[int]{Value: 99}) // 应被 claimed 守卫忽略
+		}()
+		var r Result[int]
+		go func() {
+			defer wg.Done()
+			r = f.Get(context.Background())
+		}()
+		wg.Wait()
+		assert.Equal(t, 42, r.Value, "round %d", round)
 	}
 }

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/shengyanli1982/karta/v2
 
-go 1.21
+go 1.23
 
 require (
 	github.com/prometheus/client_golang v1.21.1

--- a/group.go
+++ b/group.go
@@ -12,6 +12,10 @@ import (
 // 低于此值时，goroutine 调度开销超过并发收益，直接顺序执行。
 const seqThreshold = 128
 
+// spinLimit 是并发路径等待 worker 完成时的最大自旋次数，
+// 超过后切换为阻塞等待（避免长任务下忙自旋空转 CPU）。
+const spinLimit = 512
+
 // Group 是泛型同步批处理组件 (ADR-002)。
 // 使用 Map 对输入切片做并发处理，结果按输入顺序排列。
 type Group[In, Out any] struct {
@@ -83,16 +87,36 @@ func (g *Group[In, Out]) Map(ctx context.Context, inputs []In) []Result[Out] {
 	sh := g.pool.Get().(*mapWorkCtx[In, Out])
 	sh.reset(g, ctx, results, inputs, n)
 	sh.targetCount = int32(workers - 1)
+	// spawn 前快照 target：worker 通过 run 参数使用该局部值，
+	// doneCount.Add 之后不再读池化字段 targetCount——否则并发新 Map 可能
+	// Get+reset 同一已归还对象并同时写入该字段，构成数据竞态（P1-1）。
+	target := sh.targetCount
+
+	// done channel 不放入池化结构（池复用会残留已关闭 channel），
+	// 每次并发 Map 分配一次，随本次调用生命周期丢弃（1 alloc，可接受）
+	done := make(chan struct{})
 
 	// caller-as-worker：启动 (workers-1) 个 goroutine，调用方直接执行 run()，省一个 goroutine 分配。
-	for i := 0; i < workers-1; i++ {
-		go sh.run()
+	for range workers - 1 {
+		go sh.run(done, target)
 	}
 	sh.runAsCaller()
 
-	// 用 atomic counter + Gosched 替代 WaitGroup（对于短等待避免 pthread_cond_wait 开销）
-	for sh.doneCount.Load() < sh.targetCount {
+	// 有限自旋 + 阻塞等待：短任务自旋完成可避免 channel/调度切换开销，
+	// 自旋超限后切换阻塞等待，杜绝忙自旋空转 CPU。
+	// 同步论证（happens-before）：每个 worker 对池化字段的访问（runCore 内）
+	// happens-before 其 doneCount.Add；调用方观测到 doneCount == target
+	// happens-after 全部 Add，故 pool.Put happens-after 所有 worker 读写。
+	// targetCount 已在 spawn 前快照为局部变量 target；pool.Put 归还后，
+	// 本调用的任何 goroutine 不得再读写任何池化字段。
+	spun := 0
+	for sh.doneCount.Load() < target {
+		if spun >= spinLimit {
+			<-done // 最后一个完成的 worker 已 close(done)
+			break
+		}
 		runtime.Gosched()
+		spun++
 	}
 
 	g.pool.Put(sh)
@@ -103,7 +127,7 @@ func (g *Group[In, Out]) Map(ctx context.Context, inputs []In) []Result[Out] {
 // 通过 sync.Pool 复用，避免每次 Map 调用分配堆对象。
 type mapWorkCtx[In, Out any] struct {
 	doneCount   atomic.Int32 // worker 完成计数（替代 WaitGroup）
-	targetCount int32        // 需等待的 worker 数
+	targetCount int32        // 需等待的 worker 数（spawn 前一次写入；worker 使用 run 的快照参数，不再读本字段）
 	nextIdx     atomic.Int64
 	g           *Group[In, Out]
 	gctx        context.Context
@@ -132,10 +156,16 @@ func (sh *mapWorkCtx[In, Out]) reset(g *Group[In, Out], ctx context.Context, res
 	sh.n = n
 }
 
-// run 是 goroutine worker 的执行体，完成后递增 doneCount。
-func (sh *mapWorkCtx[In, Out]) run() {
+// run 是 goroutine worker 的执行体，完成后递增 doneCount；
+// 最后一个完成者（Add 返回值等于 target）关闭 done 唤醒调用方。
+// target 是调用方在 spawn 前捕获的 targetCount 快照：doneCount.Add 之后
+// 不得再读池化字段——此时调用方可能在 doneCount 达标后立即 pool.Put 归还
+// 本对象，并发新 Map 可同时重写这些字段。
+func (sh *mapWorkCtx[In, Out]) run(done chan<- struct{}, target int32) {
 	sh.runCore()
-	sh.doneCount.Add(1)
+	if sh.doneCount.Add(1) == target {
+		close(done)
+	}
 }
 
 // runAsCaller 是调用方 goroutine 的执行体（不参与 doneCount 计数）。
@@ -169,28 +199,27 @@ func (sh *mapWorkCtx[In, Out]) runCore() {
 		}
 	}()
 
-	// 优化 2：批量 panic 保护（整批次一个 defer，而非每个 item 一个 defer）
-	var panicErr error
-	var lastIdx int = -1 // 跟踪当前正在处理的索引
-	func() {
-		defer func() {
-			if r := recover(); r != nil {
-				panicErr = fmt.Errorf("karta: handler panic: %v", r)
-			}
-		}()
+	// per-item panic 保护：每项独立 recover，panic 后继续领取下一项
+	// （参考 mapSequCore 的重入结构）。保证每个输入恰好产生一个 Result，
+	// panic 项填充 Result{Err}，杜绝整批 recover 导致的 worker 提前退出与零值假成功
+	for {
+		idx := int(sh.nextIdx.Add(1) - 1)
+		if idx >= sh.n {
+			return
+		}
+		if workerCtx.Err() != nil {
+			sh.results[idx] = Result[Out]{Err: workerCtx.Err()}
+			continue
+		}
 
-		for {
-			idx := int(sh.nextIdx.Add(1) - 1)
-			if idx >= sh.n {
-				return
-			}
-			if workerCtx.Err() != nil {
-				sh.results[idx] = Result[Out]{Err: workerCtx.Err()}
-				continue
-			}
-
-			lastIdx = idx
-			// 优化 1：emptyCallback 快速路径，跳过接口方法调用
+		var panicErr error
+		func() {
+			defer func() {
+				if r := recover(); r != nil {
+					panicErr = fmt.Errorf("karta: handler panic: %v", r)
+				}
+			}()
+			// emptyCallback 快速路径，跳过接口方法调用
 			if !sh.isEmptyCb {
 				sh.cb.OnBefore(workerCtx, sh.inputs[idx])
 			}
@@ -199,12 +228,10 @@ func (sh *mapWorkCtx[In, Out]) runCore() {
 			if !sh.isEmptyCb {
 				sh.cb.OnAfter(workerCtx, sh.inputs[idx], val, err)
 			}
+		}()
+		if panicErr != nil {
+			sh.results[idx] = Result[Out]{Err: panicErr}
 		}
-	}()
-
-	// panic 处理：将 panic 发生的索引位置填充错误
-	if panicErr != nil && lastIdx >= 0 {
-		sh.results[lastIdx] = Result[Out]{Err: panicErr}
 	}
 }
 
@@ -304,5 +331,3 @@ func (g *Group[In, Out]) Stop() {
 		g.cancel()
 	}
 }
-
-

--- a/group_test.go
+++ b/group_test.go
@@ -191,3 +191,92 @@ func TestGroup_Map_ConcurrentSafe(t *testing.T) {
 	}
 	wg.Wait()
 }
+
+// TestGroup_Map_ConcurrentPath_AllPanic — P1 #5: 并发路径（n > seqThreshold=128）
+// 所有输入 panic 时，每个输入恰好产生一个失败 Result，
+// 不得出现零值 Result（Err==nil）假成功
+func TestGroup_Map_ConcurrentPath_AllPanic(t *testing.T) {
+	g := NewGroup[int, int](func(ctx context.Context, v int) (int, error) {
+		panic("boom")
+	}, WithGroupWorkers(4))
+	defer g.Stop()
+
+	const n = 200 // 必须 > seqThreshold(128) 才走并发路径
+	inputs := make([]int, n)
+	for i := range inputs {
+		inputs[i] = i
+	}
+
+	results := g.Map(context.Background(), inputs)
+	require.Len(t, results, n)
+	for i, r := range results {
+		require.Error(t, r.Err, "index %d 应为失败结果，禁止零值假成功", i)
+		assert.Contains(t, r.Err.Error(), "handler panic")
+	}
+}
+
+// TestGroup_Map_ConcurrentPath_PartialPanic — 并发路径交替 panic（偶数项 panic），
+// 逐位验证：panic 项为 Err，其余项结果正确
+func TestGroup_Map_ConcurrentPath_PartialPanic(t *testing.T) {
+	g := NewGroup[int, int](func(ctx context.Context, v int) (int, error) {
+		if v%2 == 0 {
+			panic("even boom")
+		}
+		return v * 10, nil
+	}, WithGroupWorkers(4))
+	defer g.Stop()
+
+	const n = 300 // 必须 > seqThreshold(128) 才走并发路径
+	inputs := make([]int, n)
+	for i := range inputs {
+		inputs[i] = i
+	}
+
+	results := g.Map(context.Background(), inputs)
+	require.Len(t, results, n)
+	for i, r := range results {
+		if i%2 == 0 {
+			require.Error(t, r.Err, "index %d 应为 panic 失败", i)
+			assert.Contains(t, r.Err.Error(), "handler panic")
+		} else {
+			require.NoError(t, r.Err, "index %d 应成功", i)
+			assert.Equal(t, i*10, r.Value)
+		}
+	}
+}
+
+// TestGroup_Map_ConcurrentLargeBatch_Race — P1-1 回归测试：并发复用同一 Group 时，
+// 大量输入强制走并发路径（n > seqThreshold），多个调用方的 mapWorkCtx 经 sync.Pool
+// 复用。修复前 worker 在 run() 内 doneCount.Add 之后普通读池化字段 sh.targetCount，
+// 而另一调用方在 pool.Put 归还后立即普通写 targetCount，二者无同步边 → 数据竞态。
+// 本测试以 ≥8 goroutine 并发调用 Map，逐位断言确定性结果，配合 go test -race -count=10 验证。
+func TestGroup_Map_ConcurrentLargeBatch_Race(t *testing.T) {
+	// 确定性计算：平方 + 偏移，便于逐位断言
+	handler := func(ctx context.Context, v int) (int, error) {
+		return v*v + 3, nil
+	}
+	g := NewGroup[int, int](handler, WithGroupWorkers(4))
+	defer g.Stop()
+
+	const n = 500 // 必须 > seqThreshold(128) 强制并发路径
+	inputs := make([]int, n)
+	for i := range inputs {
+		inputs[i] = i
+	}
+
+	const goroutines = 16 // ≥8，放大 sync.Pool 复用碰撞概率
+	var wg sync.WaitGroup
+	for i := 0; i < goroutines; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			results := g.Map(context.Background(), inputs)
+			require.Len(t, results, n)
+			for j, r := range results {
+				require.NoError(t, r.Err, "index %d 应成功", j)
+				require.Equal(t, j*j+3, r.Value, "index %d 结果应确定", j)
+			}
+		}()
+	}
+	wg.Wait()
+}

--- a/lifecycle_test.go
+++ b/lifecycle_test.go
@@ -3,7 +3,6 @@ package karta
 import (
 	"sync"
 	"sync/atomic"
-	"syscall"
 	"testing"
 	"time"
 
@@ -70,12 +69,4 @@ func TestLifecycleManager_ShutdownTimeout(t *testing.T) {
 		"Shutdown should return within timeout, not wait for slow component")
 	assert.GreaterOrEqual(t, elapsed, 80*time.Millisecond,
 		"Shutdown should wait at least until timeout fires")
-}
-
-func TestLifecycleManager_WithSignals(t *testing.T) {
-	lm := NewLifecycleManager(WithSignals(syscall.SIGUSR1, syscall.SIGUSR2))
-
-	require.Len(t, lm.signals, 2)
-	assert.Equal(t, syscall.SIGUSR1, lm.signals[0])
-	assert.Equal(t, syscall.SIGUSR2, lm.signals[1])
 }

--- a/lifecycle_unix_test.go
+++ b/lifecycle_unix_test.go
@@ -1,0 +1,21 @@
+//go:build !windows
+
+package karta
+
+import (
+	"syscall"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestLifecycleManager_WithSignals — POSIX 信号配置（SIGUSR1/SIGUSR2 在 Windows 不存在，
+// 故本测试仅在非 Windows 平台编译运行）
+func TestLifecycleManager_WithSignals(t *testing.T) {
+	lm := NewLifecycleManager(WithSignals(syscall.SIGUSR1, syscall.SIGUSR2))
+
+	require.Len(t, lm.signals, 2)
+	assert.Equal(t, syscall.SIGUSR1, lm.signals[0])
+	assert.Equal(t, syscall.SIGUSR2, lm.signals[1])
+}

--- a/middleware/metrics.go
+++ b/middleware/metrics.go
@@ -2,6 +2,8 @@ package middleware
 
 import (
 	"context"
+	"errors"
+	"fmt"
 	"time"
 
 	"github.com/prometheus/client_golang/prometheus"
@@ -38,8 +40,29 @@ func WithRegisterer(r prometheus.Registerer) MetricsOption {
 	return func(c *metricsConfig) { c.registerer = r }
 }
 
+// registerOrReuse 注册 collector，并在重复注册时复用已注册的实例。
+// 当相同配置的 collector 已注册（prometheus.AlreadyRegisteredError）时，
+// 返回注册器中已存在的实例，保证多个相同配置的中间件写入同一份指标，
+// 避免第二个实例持有未注册的 collector 导致指标静默丢失；
+// 复用时的类型不匹配或其他注册错误属于不可恢复的配置错误，直接 panic（fail-fast）。
+func registerOrReuse[C prometheus.Collector](r prometheus.Registerer, c C) C {
+	if err := r.Register(c); err != nil {
+		var are prometheus.AlreadyRegisteredError
+		if errors.As(err, &are) {
+			existing, ok := are.ExistingCollector.(C)
+			if !ok {
+				panic(fmt.Sprintf("karta middleware: already-registered collector type mismatch: want %T, got %T", c, are.ExistingCollector))
+			}
+			return existing
+		}
+		panic(fmt.Sprintf("karta middleware: failed to register prometheus collector: %v", err))
+	}
+	return c
+}
+
 // Metrics 指标采集中间件
 // 采集: handler 执行耗时 histogram, 成功/失败计数 counter
+// 相同配置的中间件重复构建时，复用已注册的 collector，指标在共享实例上累加
 func Metrics[In, Out any](opts ...MetricsOption) karta.Middleware[In, Out] {
 	cfg := &metricsConfig{
 		namespace:  "karta",
@@ -67,7 +90,7 @@ func Metrics[In, Out any](opts ...MetricsOption) karta.Middleware[In, Out] {
 		ConstLabels: cfg.labels,
 	}, []string{"status"})
 
-	errors := prometheus.NewCounter(prometheus.CounterOpts{
+	errCount := prometheus.NewCounter(prometheus.CounterOpts{
 		Namespace:   cfg.namespace,
 		Subsystem:   cfg.subsystem,
 		Name:        "errors_total",
@@ -75,10 +98,10 @@ func Metrics[In, Out any](opts ...MetricsOption) karta.Middleware[In, Out] {
 		ConstLabels: cfg.labels,
 	})
 
-	// 使用 Register 而非 MustRegister，忽略已注册错误（测试中可能重复创建）
-	_ = cfg.registerer.Register(duration)
-	_ = cfg.registerer.Register(total)
-	_ = cfg.registerer.Register(errors)
+	// 已注册的 collector 会被复用，注册失败等不可恢复错误直接 panic
+	duration = registerOrReuse(cfg.registerer, duration)
+	total = registerOrReuse(cfg.registerer, total)
+	errCount = registerOrReuse(cfg.registerer, errCount)
 
 	return func(next karta.Handler[In, Out]) karta.Handler[In, Out] {
 		return func(ctx context.Context, input In) (Out, error) {
@@ -89,7 +112,7 @@ func Metrics[In, Out any](opts ...MetricsOption) karta.Middleware[In, Out] {
 			duration.Observe(elapsed.Seconds())
 			if err != nil {
 				total.WithLabelValues("error").Inc()
-				errors.Inc()
+				errCount.Inc()
 			} else {
 				total.WithLabelValues("success").Inc()
 			}

--- a/middleware/metrics_test.go
+++ b/middleware/metrics_test.go
@@ -223,3 +223,96 @@ func TestMetrics_WithLabels(t *testing.T) {
 		}
 	}
 }
+
+// TestMetrics_ReuseRegisteredCollectors 同一 Registry 上构建两个相同配置的中间件时，
+// 第二个实例复用已注册的 collector，两个中间件的指标在同一实例上正确累加
+func TestMetrics_ReuseRegisteredCollectors(t *testing.T) {
+	reg := prometheus.NewRegistry()
+
+	mw1 := Metrics[int, int](WithRegisterer(reg), WithNamespace("test"), WithSubsystem("reuse"))
+	mw2 := Metrics[int, int](WithRegisterer(reg), WithNamespace("test"), WithSubsystem("reuse"))
+
+	h1 := mw1(func(ctx context.Context, input int) (int, error) {
+		return input, nil
+	})
+	h2 := mw2(func(ctx context.Context, input int) (int, error) {
+		if input < 0 {
+			return 0, errors.New("negative input")
+		}
+		return input, nil
+	})
+
+	// h1: 2 次成功; h2: 1 次成功 + 1 次失败
+	for i := 0; i < 2; i++ {
+		_, err := h1(context.Background(), i)
+		require.NoError(t, err)
+	}
+	_, err := h2(context.Background(), 1)
+	require.NoError(t, err)
+	_, err = h2(context.Background(), -1)
+	require.Error(t, err)
+
+	// histogram 样本数 = 4；若第二个中间件持有未注册的 collector，Gather 只能看到 2
+	count, _ := findMetricFamily(t, reg, "test_reuse_execution_duration_seconds")
+	assert.Equal(t, uint64(4), count, "两个中间件应共享同一个 histogram")
+
+	// total 计数累加: success=3, error=1
+	assert.Equal(t, float64(3), getCounterVecValue(t, reg, "test_reuse_total", "success"))
+	assert.Equal(t, float64(1), getCounterVecValue(t, reg, "test_reuse_total", "error"))
+
+	// errors_total = 1
+	_, errVal := findMetricFamily(t, reg, "test_reuse_errors_total")
+	assert.Equal(t, float64(1), errVal)
+}
+
+// failingRegisterer 模拟注册时返回非 AlreadyRegisteredError 错误的注册器
+type failingRegisterer struct {
+	err error
+}
+
+func (r failingRegisterer) Register(prometheus.Collector) error { return r.err }
+
+func (r failingRegisterer) MustRegister(...prometheus.Collector) { panic(r.err) }
+
+func (r failingRegisterer) Unregister(prometheus.Collector) bool { return false }
+
+// TestMetrics_PanicsOnRegisterError 非 AlreadyRegisteredError 的注册错误应 panic（fail-fast）
+func TestMetrics_PanicsOnRegisterError(t *testing.T) {
+	reg := failingRegisterer{err: errors.New("registry unavailable")}
+
+	defer func() {
+		rec := recover()
+		require.NotNil(t, rec, "注册失败时应 panic")
+		msg, ok := rec.(string)
+		require.True(t, ok, "panic 值应为带说明的字符串")
+		assert.Contains(t, msg, "karta middleware")
+		assert.Contains(t, msg, "registry unavailable")
+	}()
+
+	_ = Metrics[int, int](WithRegisterer(reg), WithNamespace("test"), WithSubsystem("fail"))
+}
+
+// TestMetrics_PanicsOnCollectorTypeMismatch 同名但不同类型的 collector 已注册时，
+// 复用失败应 panic（fail-fast），而不是静默丢失指标
+func TestMetrics_PanicsOnCollectorTypeMismatch(t *testing.T) {
+	reg := prometheus.NewRegistry()
+	// 与 histogram 同名同 help 的 counter 抢占注册（help 必须一致，
+	// 否则 Registry 的一致性检查会先于去重检查返回普通错误）
+	conflict := prometheus.NewCounter(prometheus.CounterOpts{
+		Namespace: "test",
+		Subsystem: "mis",
+		Name:      "execution_duration_seconds",
+		Help:      "Handler execution duration in seconds",
+	})
+	require.NoError(t, reg.Register(conflict))
+
+	defer func() {
+		rec := recover()
+		require.NotNil(t, rec, "类型不匹配时应 panic")
+		msg, ok := rec.(string)
+		require.True(t, ok, "panic 值应为带说明的字符串")
+		assert.Contains(t, msg, "type mismatch")
+	}()
+
+	_ = Metrics[int, int](WithRegisterer(reg), WithNamespace("test"), WithSubsystem("mis"))
+}

--- a/middleware_integration_test.go
+++ b/middleware_integration_test.go
@@ -171,6 +171,41 @@ func TestPipeline_MiddlewareChain_WithSubmitHandler(t *testing.T) {
 	assert.Equal(t, int64(1), counter.Load(), "middleware should wrap even per-task handler")
 }
 
+func TestPipeline_Middleware_WithRecovery(t *testing.T) {
+	// Pipeline 默认提交路径（Submit）走 executor 启动时预包裹 middleware 的
+	// defaultHandler。handler panic 时，recovery middleware 应先捕获并转为
+	// 错误结果，future 得到 error 而非进程崩溃，executor 自身的 recover 不触发。
+	recoveryMW := Middleware[int, string](func(next Handler[int, string]) Handler[int, string] {
+		return func(ctx context.Context, input int) (out string, err error) {
+			defer func() {
+				if rec := recover(); rec != nil {
+					out = ""
+					err = fmt.Errorf("middleware recovered: %v", rec)
+				}
+			}()
+			return next(ctx, input)
+		}
+	})
+
+	handler := func(ctx context.Context, v int) (string, error) {
+		panic("handler exploded")
+	}
+
+	sched := NewSimpleScheduler(16)
+	p := NewPipeline[int, string](handler, sched, WithPipelineMiddleware(recoveryMW))
+	require.NotNil(t, p)
+	defer p.Stop()
+
+	f, err := p.Submit(context.Background(), 1)
+	require.NoError(t, err)
+	r := f.Get(context.Background())
+	require.Error(t, r.Err)
+	// middleware recovery 捕获 panic，executor 的 recover 不再触发
+	assert.Contains(t, r.Err.Error(), "middleware recovered")
+	assert.Contains(t, r.Err.Error(), "handler exploded")
+	assert.NotContains(t, r.Err.Error(), "karta: handler panic")
+}
+
 func TestGroup_Middleware_WithRecovery(t *testing.T) {
 	// 手写 recovery middleware：若 handler panic，middleware 捕获后返回自定义错误，
 	// 而不是让 panic 传播到 safeCall 的 recover。
@@ -218,13 +253,17 @@ func TestGroup_NoMiddleware_NoOverhead(t *testing.T) {
 	}
 }
 
-func TestToMiddlewareSlice_TypeMismatchSilent(t *testing.T) {
-	// 类型不匹配的 middleware 被静默忽略，只保留类型匹配的
+func TestToMiddlewareSlice_TypeMismatchPanics(t *testing.T) {
+	// P1 #4: 类型不匹配的 middleware 不再静默忽略，fail-fast panic
 	mw1 := countMiddleware[int, int](&atomic.Int64{})    // Middleware[int, int]
 	mw2 := countMiddleware[int, string](&atomic.Int64{}) // Middleware[int, string] ← 类型不匹配
 
-	result := toMiddlewareSlice[int, int]([]any{mw1, mw2})
-	// mw2 类型为 Middleware[int, string]，断言 Middleware[int, int] 失败，被忽略
+	require.Panics(t, func() {
+		toMiddlewareSlice[int, int]([]any{mw1, mw2})
+	})
+
+	// 全部匹配时正常转换
+	result := toMiddlewareSlice[int, int]([]any{mw1})
 	assert.Len(t, result, 1)
 }
 

--- a/pipeline.go
+++ b/pipeline.go
@@ -17,15 +17,16 @@ type Pipeline[In, Out any] struct {
 	handler       Handler[In, Out]
 	scheduler     Scheduler
 	opts          *pipelineOptions
+	mws           []Middleware[In, Out] // NewPipeline 时一次性类型断言（类型不匹配 panic），此后只读
 	ctx           context.Context
 	cancel        context.CancelFunc
 	wg            sync.WaitGroup
 	once          sync.Once
 	closed        atomic.Bool
 	running       atomic.Int64
-	pendingMu     sync.Mutex                 // 与 pending 配合，替换 sync.Map
+	pendingMu     sync.Mutex                     // 保护 pending/closed/wg.Add 的共享临界区
 	pending       map[*TaskEnvelope]*Future[Out] // 替换 sync.Map，减少热路径分配
-	workerLimiter *rate.Limiter // worker spawn 速率控制
+	workerLimiter *rate.Limiter                  // worker spawn 速率控制
 }
 
 // NewPipeline 创建并启动一个 Pipeline
@@ -53,6 +54,7 @@ func NewPipeline[In, Out any](
 		handler:       handler,
 		scheduler:     scheduler,
 		opts:          o,
+		mws:           toMiddlewareSlice[In, Out](o.middleware),
 		ctx:           ctx,
 		cancel:        cancel,
 		pending:       make(map[*TaskEnvelope]*Future[Out]),
@@ -70,25 +72,35 @@ func NewPipeline[In, Out any](
 	return p
 }
 
-// Submit 提交任务，使用默认 handler，返回 Future
+// Submit 提交任务，使用默认 handler，返回 Future。
+// envelope 不携带 per-task Handler（保持 nil），executor 使用启动时
+// 已预包裹 middleware 的 defaultHandler，避免每任务重复 Chain 包裹。
 func (p *Pipeline[In, Out]) Submit(ctx context.Context, input In) (*Future[Out], error) {
-	return p.submitInternal(ctx, p.handler, input, 0)
+	return p.submitInternal(ctx, nil, input, 0)
 }
 
-// SubmitWithHandler 提交任务，使用指定的 handler 覆盖默认 handler
+// SubmitWithHandler 提交任务，使用指定的 handler 覆盖默认 handler。
+// 这是唯一设置 envelope.Handler 的提交路径；handler 为 nil 时等同于
+// 使用默认 handler（见 TaskEnvelope.Handler 的 nil 语义）。
 func (p *Pipeline[In, Out]) SubmitWithHandler(ctx context.Context, handler Handler[In, Out], input In) (*Future[Out], error) {
 	return p.submitInternal(ctx, handler, input, 0)
 }
 
-// SubmitAfter 延迟提交任务，delay 后入队
+// SubmitAfter 延迟提交任务，delay 后入队。
+// 与 Submit 相同，envelope 不携带 per-task Handler。
 func (p *Pipeline[In, Out]) SubmitAfter(ctx context.Context, input In, delay time.Duration) (*Future[Out], error) {
-	return p.submitInternal(ctx, p.handler, input, delay)
+	return p.submitInternal(ctx, nil, input, delay)
 }
 
 // Stop 关闭 pipeline，幂等操作
 func (p *Pipeline[In, Out]) Stop() {
 	p.once.Do(func() {
+		// closed 必须在 pendingMu 临界区内设置：Submit/trySpawnWorker 在
+		// 同一把锁下完成 closed 检查与 wg.Add，保证 wg.Wait 开始后
+		// 不会再有新的 wg.Add（杜绝 WaitGroup misuse）
+		p.pendingMu.Lock()
 		p.closed.Store(true)
+		p.pendingMu.Unlock()
 		p.cancel()
 		p.scheduler.Shutdown()
 		p.wg.Wait()
@@ -108,49 +120,63 @@ func (p *Pipeline[In, Out]) GetWorkerNumber() int64 {
 }
 
 // submitInternal 统一的提交入口
+//
+// handler 为 nil 表示不携带 per-task 覆盖（envelope.Handler 保持 nil），
+// executor 将使用启动时预包裹 middleware 的 defaultHandler；
+// 仅 SubmitWithHandler 传入非 nil handler 设置 per-task 覆盖。
+//
+// 并发安全不变量：closed 检查、pending 写入、wg.Add(1) 三者必须在同一个
+// pendingMu 临界区内完成（与 Stop 中同一把锁下设置 closed 配合），
+// 保证 Stop 的 wg.Wait 开始后不会再出现新的 wg.Add。
 func (p *Pipeline[In, Out]) submitInternal(
 	ctx context.Context,
 	handler Handler[In, Out],
 	input In,
 	delay time.Duration,
 ) (*Future[Out], error) {
-	if p.closed.Load() {
-		return nil, ErrPipelineClosed
-	}
-
 	future := NewPendingFuture[Out]()
 	envelope := getEnvelope()
 	envelope.Input = input
-	envelope.Handler = handler
-	envelope.Delay = delay
-	envelope.CreatedAt = time.Now()
+	// handler 为 nil 时不得赋值 envelope.Handler：Handler 是函数类型，
+	// typed nil 赋给 any 字段会得到非 nil 的 interface 值，executor 将误判为
+	// per-task 覆盖并调用 nil 函数（panic）。池化 envelope 的 Handler 已被
+	// putEnvelope 清零，保持 nil 即走默认 handler 路径。
+	if handler != nil {
+		envelope.Handler = handler
+	}
 	envelope.UserCtx = ctx
+	envelope.CreatedAt = time.Now()
 
 	if delay > 0 {
 		// 延迟提交：goroutine 等待 timer 触发后入队
-		// wg.Add 在 closed 检查之前，确保 Stop 的 wg.Wait 能等待此 goroutine，
-		// 从而 pending 清理能覆盖所有 delayed future
-		p.wg.Add(1)
+		envelope.Delay = delay
+		p.pendingMu.Lock()
 		if p.closed.Load() {
-			p.wg.Done()
+			p.pendingMu.Unlock()
 			putEnvelope(envelope)
 			return nil, ErrPipelineClosed
 		}
+		p.wg.Add(1)
+		p.pendingMu.Unlock()
 		go func() {
 			defer p.wg.Done()
 			timer := time.NewTimer(delay)
 			defer timer.Stop()
 			select {
 			case <-timer.C:
-				// timer 触发时再次检查 closed，缩小与 Stop 的竞态窗口：
-				// 若 pipeline 已关闭，直接 resolve future，不存入 pending
+				// 延迟等待已由本 goroutine 完成，入队前清零 Delay，
+				// 防止 Delay-aware 调度器（如 scheduler 包的 delay/timer）二次施加延迟
+				envelope.Delay = 0
+				// timer 触发时再次检查 closed：若 pipeline 已关闭，
+				// 直接 resolve future，不存入 pending
+				p.pendingMu.Lock()
 				if p.closed.Load() {
+					p.pendingMu.Unlock()
 					future.Resolve(Result[Out]{Err: ErrPipelineClosed})
 					putEnvelope(envelope)
 					return
 				}
 				// 先存 pending 再入队，避免 executor 取走时找不到 future
-				p.pendingMu.Lock()
 				p.pending[envelope] = future
 				p.pendingMu.Unlock()
 				err := p.scheduler.Enqueue(envelope)
@@ -160,7 +186,9 @@ func (p *Pipeline[In, Out]) submitInternal(
 					p.pendingMu.Unlock()
 					future.Resolve(Result[Out]{Err: err})
 					putEnvelope(envelope)
+					return
 				}
+				p.trySpawnWorker() // 与即时路径对称：按需启动新 worker
 			case <-p.ctx.Done():
 				future.Resolve(Result[Out]{Err: p.ctx.Err()})
 				putEnvelope(envelope)
@@ -172,8 +200,14 @@ func (p *Pipeline[In, Out]) submitInternal(
 		return future, nil
 	}
 
-	// 即时提交：先存 pending 再入队，避免 executor 取走时找不到 future
+	// 即时提交：closed 检查与 pending 写入同处一个临界区，
+	// 先存 pending 再入队，避免 executor 取走时找不到 future
 	p.pendingMu.Lock()
+	if p.closed.Load() {
+		p.pendingMu.Unlock()
+		putEnvelope(envelope)
+		return nil, ErrPipelineClosed
+	}
 	p.pending[envelope] = future
 	p.pendingMu.Unlock()
 	err := p.scheduler.Enqueue(envelope)
@@ -190,6 +224,9 @@ func (p *Pipeline[In, Out]) submitInternal(
 
 // executor 是 worker goroutine，从 scheduler 取任务并执行
 // 支持 idle timeout 自动退出（保留至少 1 个 worker）
+//
+// running 记账：started != nil 时（NewPipeline 启动）由本函数登记名额；
+// started == nil 时（trySpawnWorker 启动）名额已在调用方 CAS 中预留，此处不再 Add
 func (p *Pipeline[In, Out]) executor(started chan<- struct{}) {
 	idleExit := false
 	defer func() {
@@ -198,22 +235,20 @@ func (p *Pipeline[In, Out]) executor(started chan<- struct{}) {
 		}
 		p.wg.Done()
 	}()
-	p.running.Add(1)
 	if started != nil {
+		p.running.Add(1)
 		close(started) // 通知调用方 executor 已就绪
 	}
 
 	lastActive := time.Now().UnixMilli()
 
-	// middleware pre-wrap: 类型断言 + Chain 包裹只执行一次（per executor，避免共享写竞争）
+	// middleware pre-wrap: Chain 包裹只执行一次（per executor，避免共享写竞争）
+	// p.mws 在 NewPipeline 时一次性完成类型断言（类型不匹配 panic），此后只读；
 	// 读取 p.handler 是安全的（NewPipeline 返回后不再写入），但不可写回 p.handler
 	defaultHandler := p.handler
-	var mws []Middleware[In, Out]
-	if len(p.opts.middleware) > 0 {
-		mws = toMiddlewareSlice[In, Out](p.opts.middleware)
-		if len(mws) > 0 {
-			defaultHandler = Chain(mws...)(p.handler)
-		}
+	mws := p.mws
+	if len(mws) > 0 {
+		defaultHandler = Chain(mws...)(p.handler)
 	}
 
 	// Hot Path 1: 在循环外创建可复用的 timer，避免每轮 context.WithTimeout 分配
@@ -225,13 +260,8 @@ func (p *Pipeline[In, Out]) executor(started chan<- struct{}) {
 	ss, _ := p.scheduler.(*SimpleScheduler)
 
 	for {
-		// 正确 Reset timer：先 Stop + drain，再 Reset
-		if !scanTimer.Stop() {
-			select {
-			case <-scanTimer.C:
-			default:
-			}
-		}
+		// Go 1.23+：Reset 保证调用后不会收到此前未取走的过期 tick，
+		// 无需 Stop + drain 样板
 		scanTimer.Reset(p.opts.scanInterval)
 
 		var envelope *TaskEnvelope
@@ -291,7 +321,19 @@ func (p *Pipeline[In, Out]) executor(started chan<- struct{}) {
 
 		future := p.loadAndDeletePending(envelope)
 		if future == nil {
-			// future 已被取消/超时清理，仍需 Done 释放租约/死信标记
+			// future 已被取消/超时清理（lease 重投递或 Stop 清理场景），
+			// 仍需 Done 释放租约/死信标记。
+			// 归还不变量：envelope 恰好归还一次，且归还原持有者执行——
+			// 原持有 executor（或提交路径）完成时 putEnvelope；此处若再归还，
+			// 将与原持有者的归还形成双重归还，污染池中其他任务。故只 Done，不 putEnvelope。
+			p.scheduler.Done(envelope)
+			continue
+		}
+
+		// UserCtx 已取消的任务直接以取消错误完成，不执行 handler，
+		// 完成路径（Resolve → Done → 归还 envelope）与其他路径保持一致
+		if envelope.UserCtx != nil && envelope.UserCtx.Err() != nil {
+			future.Resolve(Result[Out]{Err: envelope.UserCtx.Err()})
 			p.scheduler.Done(envelope)
 			putEnvelope(envelope)
 			continue
@@ -309,10 +351,10 @@ func (p *Pipeline[In, Out]) executor(started chan<- struct{}) {
 		}
 
 		// Hot Path 2 v2: 仅在 UserCtx 有可观察取消信号时才创建 cancel context
-		// 三条快速路径 (0 extra allocs)：
+		// （UserCtx 已取消的任务已在上方短路，不会执行到此处）
+		// 两条快速路径 (0 extra allocs)：
 		//   1. UserCtx == nil：无调用方 context
 		//   2. UserCtx.Done() == nil：context.Background()/TODO()，永不取消
-		//   3. UserCtx.Err() != nil：已取消，AfterFunc 会立刻 fire 但 handler 已在 p.ctx 下运行
 		var taskCtx context.Context
 		var taskCancel context.CancelFunc
 		var stopAfterFunc func() bool
@@ -369,16 +411,33 @@ func (p *Pipeline[In, Out]) loadAndDeletePending(envelope *TaskEnvelope) *Future
 
 // trySpawnWorker 尝试在 worker 数量未达上限时启动新 worker
 // 受 rate.Limiter 控制，避免瞬间 spawn 过多 worker
+//
+// CAS 循环先预留 running 名额再 spawn，杜绝 check-then-spawn 的
+// TOCTOU 窗口（并发提交时可能超出 workers 上限）；closed 检查与
+// wg.Add 同处 pendingMu 临界区，与 Stop 的 wg.Wait 互斥
 func (p *Pipeline[In, Out]) trySpawnWorker() {
-	if p.running.Load() >= int64(p.opts.workers) {
+	// 预留名额：超过上限则不 spawn
+	for {
+		cur := p.running.Load()
+		if cur >= int64(p.opts.workers) {
+			return
+		}
+		if p.running.CompareAndSwap(cur, cur+1) {
+			break
+		}
+	}
+	// 名额不足（限流）：归还预留名额
+	if !p.workerLimiter.Allow() {
+		p.running.Add(-1)
 		return
 	}
-	if !p.workerLimiter.Allow() {
+	p.pendingMu.Lock()
+	if p.closed.Load() {
+		p.pendingMu.Unlock()
+		p.running.Add(-1)
 		return
 	}
 	p.wg.Add(1)
-	started := make(chan struct{})
-	go p.executor(started)
-	<-started
+	p.pendingMu.Unlock()
+	go p.executor(nil)
 }
-

--- a/pipeline_delay_regression_test.go
+++ b/pipeline_delay_regression_test.go
@@ -1,0 +1,36 @@
+package karta_test
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/shengyanli1982/karta/v2/scheduler"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	karta "github.com/shengyanli1982/karta/v2"
+)
+
+// TestSubmitAfter_NoDoubleDelay — P1 #2 回归测试：
+// SubmitAfter 的延迟已由 Pipeline 侧 goroutine 等待完成，入队前清零 envelope.Delay，
+// Delay-aware 调度器不得二次施加延迟（修复前实际总耗时 ≈ 2×delay，必然 ≥120ms）
+func TestSubmitAfter_NoDoubleDelay(t *testing.T) {
+	handler := karta.Handler[int, int](func(ctx context.Context, input int) (int, error) {
+		return input * 2, nil
+	})
+	p := karta.NewPipeline[int, int](handler, scheduler.NewDelayScheduler(), karta.WithPipelineWorkers(2))
+	defer p.Stop()
+
+	start := time.Now()
+	f, err := p.SubmitAfter(context.Background(), 21, 50*time.Millisecond)
+	require.NoError(t, err)
+
+	getCtx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	res := f.Get(getCtx)
+	require.NoError(t, res.Err)
+	assert.Equal(t, 42, res.Value)
+	assert.Less(t, time.Since(start), 120*time.Millisecond,
+		"总耗时应 ≈ 一次 delay（50ms）+ 调度开销；≥120ms 说明延迟被施加了两次")
+}

--- a/pipeline_test.go
+++ b/pipeline_test.go
@@ -4,7 +4,9 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"math/rand/v2"
 	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -896,4 +898,89 @@ func TestPipeline_TrySpawn_RateLimiterReject(t *testing.T) {
 	assert.GreaterOrEqual(t, wAfter, int64(1))
 
 	time.Sleep(1500 * time.Millisecond) // wait tasks complete
+}
+
+// TestPipeline_Submit_AlreadyCancelledCtx — P1 #7: 已取消 UserCtx 的任务
+// 直接以取消错误完成，handler 不得执行
+func TestPipeline_Submit_AlreadyCancelledCtx(t *testing.T) {
+	var called atomic.Int64
+	handler := func(ctx context.Context, n int) (int, error) {
+		called.Add(1)
+		return n, nil
+	}
+	p := NewPipeline[int, int](handler, NewSimpleScheduler(16), WithPipelineWorkers(2))
+	require.NotNil(t, p)
+	defer p.Stop()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel() // 提交前已取消
+
+	f, err := p.Submit(ctx, 1)
+	require.NoError(t, err)
+
+	getCtx, getCancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer getCancel()
+	res := f.Get(getCtx)
+	assert.ErrorIs(t, res.Err, context.Canceled, "future 应立即得到 context.Canceled")
+	assert.Zero(t, called.Load(), "handler 不应被调用")
+
+	// pipeline 后续仍正常可用
+	f2, err := p.Submit(context.Background(), 2)
+	require.NoError(t, err)
+	res2 := f2.Get(getCtx)
+	require.NoError(t, res2.Err)
+	assert.Equal(t, 2, res2.Value)
+}
+
+// TestPipeline_SubmitStop_Stress — P1 #6 压力测试:
+// 并发 goroutine 循环 Submit/SubmitAfter(1ms)，另一 goroutine 随机时机 Stop。
+// closed 检查/pending 写入/wg.Add 同处 pendingMu 临界区，
+// -race -count=10 下不得出现 WaitGroup misuse panic 或竞态
+func TestPipeline_SubmitStop_Stress(t *testing.T) {
+	for range 10 {
+		p := NewPipeline[int, int](
+			func(ctx context.Context, n int) (int, error) { return n, nil },
+			NewSimpleScheduler(1024),
+			WithPipelineWorkers(4),
+		)
+
+		stopCh := make(chan struct{})
+		var subWG sync.WaitGroup
+		for g := range 4 {
+			subWG.Add(1)
+			go func(id int) {
+				defer subWG.Done()
+				for i := 0; ; i++ {
+					select {
+					case <-stopCh:
+						return
+					default:
+					}
+					var f *Future[int]
+					var err error
+					if i%2 == 0 {
+						f, err = p.Submit(context.Background(), id*10000+i)
+					} else {
+						f, err = p.SubmitAfter(context.Background(), id*10000+i, time.Millisecond)
+					}
+					if err != nil {
+						continue
+					}
+					_ = f.Get(context.Background())
+				}
+			}(g)
+		}
+
+		// 独立 goroutine 随机时机 Stop（幂等）
+		stopDone := make(chan struct{})
+		go func() {
+			defer close(stopDone)
+			time.Sleep(time.Duration(rand.IntN(20)+1) * time.Millisecond)
+			p.Stop()
+		}()
+
+		<-stopDone
+		close(stopCh)
+		subWG.Wait()
+	}
 }

--- a/scheduler.go
+++ b/scheduler.go
@@ -16,6 +16,8 @@ type Scheduler interface {
 	// Enqueue 将任务入队到调度器
 	// 若调度器已关闭，返回 ErrSchedulerClosed
 	// 若缓冲区已满，返回 ErrSchedulerFull
+	// 注意：Bounded 调度器（scheduler.NewBoundedScheduler）满时可能短暂阻塞
+	// 后再返回 ErrSchedulerFull（容量预检与 Put 之间的残余 TOCTOU，见 bounded.go）
 	Enqueue(task *TaskEnvelope) error
 
 	// Dequeue 从调度器中获取任务，支持 context 取消

--- a/scheduler/bounded.go
+++ b/scheduler/bounded.go
@@ -13,7 +13,7 @@ import (
 /*
 
   特点：
-  - 队列满时，Enqueue 会阻塞直到有空间或调度器关闭
+  - 队列满时，Enqueue 立即返回 karta.ErrSchedulerFull（遵守接口契约，不阻塞调用方）
   - Dequeue 支持 context 取消，使用底层队列的 GetWithContext
   - 容量由 NewBoundedScheduler 参数指定
 
@@ -40,8 +40,16 @@ func (s *boundedScheduler) Enqueue(task *karta.TaskEnvelope) error {
 	if s.closed.Load() {
 		return karta.ErrSchedulerClosed
 	}
-	// 使用 context.Background() 使 Enqueue 可被底层队列 Shutdown 唤醒
-	if err := s.queue.PutWithContext(context.Background(), task); err != nil {
+	// BoundedBlockingQueue 没有非阻塞 TryPut 类 API（已查证 workqueue v2.3.2
+	// 源码：Put/PutWithContext 均需先获取槽位信号）。按 karta.Scheduler 接口
+	// 契约（缓冲区已满返回 ErrSchedulerFull），先做容量检查快速拒绝，再入队。
+	// 残余竞态说明：检查与 Put 之间若被并发写入占掉最后空位，Put 会短暂
+	// 阻塞于槽位等待，直至其他入队/出队操作或 Shutdown 释放槽位；
+	// 这是最小正确组合，不会再出现队列已满仍无限阻塞的违约行为。
+	if s.queue.Len() >= s.queue.Cap() {
+		return karta.ErrSchedulerFull
+	}
+	if err := s.queue.Put(task); err != nil {
 		if errors.Is(err, workqueue.ErrQueueIsClosed) {
 			return karta.ErrSchedulerClosed
 		}

--- a/scheduler/bounded_test.go
+++ b/scheduler/bounded_test.go
@@ -88,8 +88,8 @@ func TestBounded_DequeueAfterShutdown(t *testing.T) {
 	assert.ErrorIs(t, err, karta.ErrSchedulerClosed)
 }
 
-func TestBounded_BlockingEnqueue(t *testing.T) {
-	// capacity=2，填满后第三次 Enqueue 应阻塞
+func TestBounded_FullReturnsErrSchedulerFull(t *testing.T) {
+	// capacity=2，填满后 Enqueue 应立即返回 ErrSchedulerFull（不阻塞）
 	s := NewBoundedScheduler(2)
 	defer s.Shutdown()
 
@@ -97,21 +97,11 @@ func TestBounded_BlockingEnqueue(t *testing.T) {
 	require.NoError(t, s.Enqueue(&karta.TaskEnvelope{Input: 2}))
 	assert.Equal(t, 2, s.Len())
 
-	// 第三次 Enqueue 应该阻塞，在另一个 goroutine 中执行
-	done := make(chan error, 1)
-	go func() {
-		done <- s.Enqueue(&karta.TaskEnvelope{Input: 3})
-	}()
+	err := s.Enqueue(&karta.TaskEnvelope{Input: 3})
+	assert.ErrorIs(t, err, karta.ErrSchedulerFull)
+	assert.Equal(t, 2, s.Len())
 
-	// 等待短暂时间确认 Enqueue 确实在阻塞
-	select {
-	case <-done:
-		t.Fatal("third Enqueue should have blocked")
-	case <-time.After(100 * time.Millisecond):
-		// 预期行为：Enqueue 在阻塞
-	}
-
-	// 消费一个任务以释放空间
+	// 消费一个任务释放空间后，Enqueue 重新成功
 	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
 	defer cancel()
 
@@ -120,43 +110,20 @@ func TestBounded_BlockingEnqueue(t *testing.T) {
 	assert.Equal(t, 1, env.Input)
 	s.Done(env)
 
-	// 第三次 Enqueue 现在应该成功
-	select {
-	case err := <-done:
-		assert.NoError(t, err)
-	case <-time.After(2 * time.Second):
-		t.Fatal("third Enqueue should have unblocked after Dequeue")
-	}
+	require.NoError(t, s.Enqueue(&karta.TaskEnvelope{Input: 3}))
+	assert.Equal(t, 2, s.Len())
 }
 
-func TestBounded_ShutdownUnblocksEnqueue(t *testing.T) {
+func TestBounded_EnqueueAfterShutdown(t *testing.T) {
 	s := NewBoundedScheduler(1)
 
-	// 填满队列
+	// 填满队列后关闭
 	require.NoError(t, s.Enqueue(&karta.TaskEnvelope{Input: 1}))
-
-	// 在另一个 goroutine 中阻塞 Enqueue
-	done := make(chan error, 1)
-	go func() {
-		done <- s.Enqueue(&karta.TaskEnvelope{Input: 2})
-	}()
-
-	// 确认 Enqueue 在阻塞
-	select {
-	case <-done:
-		t.Fatal("Enqueue should have blocked")
-	case <-time.After(100 * time.Millisecond):
-	}
-
-	// Shutdown 应唤醒阻塞的 Enqueue
 	s.Shutdown()
 
-	select {
-	case err := <-done:
-		assert.ErrorIs(t, err, karta.ErrSchedulerClosed)
-	case <-time.After(2 * time.Second):
-		t.Fatal("Shutdown should have unblocked Enqueue")
-	}
+	// 关闭优先于满：返回 ErrSchedulerClosed 而非 ErrSchedulerFull
+	err := s.Enqueue(&karta.TaskEnvelope{Input: 2})
+	assert.ErrorIs(t, err, karta.ErrSchedulerClosed)
 }
 
 func TestBounded_Len(t *testing.T) {

--- a/scheduler/composite.go
+++ b/scheduler/composite.go
@@ -2,7 +2,10 @@ package scheduler
 
 import (
 	"context"
+	"errors"
+	"sync"
 	"sync/atomic"
+	"time"
 
 	karta "github.com/shengyanli1982/karta/v2"
 )
@@ -10,24 +13,90 @@ import (
 // 编译期接口检查：确保 compositeScheduler 实现 Scheduler 接口
 var _ karta.Scheduler = (*compositeScheduler)(nil)
 
+// pumpRetryDelay 是搬运泵向已满的下一级重试入队的间隔。
+const pumpRetryDelay = 10 * time.Millisecond
+
 // compositeScheduler 将多个 karta.Scheduler 组合为单一调度器。
 //
-// 入队写入第一个 scheduler（入口），出队从最后一个 scheduler 取（出口），
-// 适用于需要在处理链路中经过多个调度阶段的场景。
+// 入队写入第一个 scheduler（入口），出队从最后一个 scheduler 取（出口）。
+// 相邻两级之间由搬运泵（pump goroutine）搬运任务：泵从第 i 级 Dequeue
+// 并 Enqueue 到第 i+1 级，保证任务沿链路流向出口而不会滞留在中间级。
 type compositeScheduler struct {
 	schedulers []karta.Scheduler
 	closed     atomic.Bool
+	stopCh     chan struct{} // Shutdown 时关闭，通知搬运泵退出
+	wg         sync.WaitGroup
+	inflight   atomic.Int64 // 泵已取出、尚未交付下一级的在途任务数
 }
 
 // NewCompositeScheduler 创建组合调度器。
 // schedulers 按顺序组成处理链路：
 //   - Enqueue 写入 schedulers[0]
 //   - Dequeue 从 schedulers[len-1] 取出
-//   - Shutdown 依次关闭所有 schedulers
-//   - Len 返回所有 schedulers 的 Len 之和
+//   - 相邻级之间的搬运泵自动将任务从第 i 级迁移到第 i+1 级
+//   - Shutdown 级联关闭所有 schedulers，并等待搬运泵全部退出
+//   - Len 返回各级 Len 之和加上搬运泵的在途任务数，表示链路中的任务总数。
+//     注意 Len 是最终一致的快照：任务正被交付给下一级的瞬间会同时计入
+//     目标级与在途计数（至多每个活跃的泵多计 1），交付完成后收敛到真实值
+//
+// 交付语义（lease/retry 类源级 + 下游背压 = 至少一次交付）：下一级已满时，
+// 搬运泵按 pumpRetryDelay 退避重试直至交付成功；在此背压窗口内，任务尚未
+// Done 确认，若源级为租约/重试类调度器（Lease/Retry），租约过期或重试判定
+// 会触发底层将同一逻辑任务重新入队，导致该任务被多次交付与执行——handler
+// 副作用可能重复，同一 envelope 的 Future 完成是幂等的、不受影响；需要恰好
+// 一次副作用语义的业务方应自行保证 handler 幂等。
 func NewCompositeScheduler(schedulers ...karta.Scheduler) karta.Scheduler {
-	return &compositeScheduler{
+	s := &compositeScheduler{
 		schedulers: schedulers,
+		stopCh:     make(chan struct{}),
+	}
+	for i := 0; i+1 < len(schedulers); i++ {
+		s.wg.Add(1)
+		go s.pump(schedulers[i], schedulers[i+1])
+	}
+	return s
+}
+
+// pump 将任务从 from 级搬运到 to 级，直到调度器关闭或某一端不可用。
+func (s *compositeScheduler) pump(from, to karta.Scheduler) {
+	defer s.wg.Done()
+	for {
+		task, err := from.Dequeue(context.Background())
+		if err != nil {
+			// from 级已关闭（Shutdown 级联）或出错：退出泵
+			return
+		}
+		s.inflight.Add(1)
+		delivered := s.deliver(to, task)
+		s.inflight.Add(-1)
+		if !delivered {
+			// to 级已关闭或正在关闭：任务无法交付，退出泵。
+			// 关闭期间丢弃在途任务符合 Shutdown 语义。
+			return
+		}
+		// 任务已交付下一级，确认 from 级上的处理完成
+		// （对租约类调度器尤其必要，否则租约过期会重复投递任务）。
+		from.Done(task)
+	}
+}
+
+// deliver 将任务入队到下一级：下一级已满（ErrSchedulerFull）时退避重试，
+// 直到成功或调度器关闭。返回 false 表示应放弃交付。
+func (s *compositeScheduler) deliver(to karta.Scheduler, task *karta.TaskEnvelope) bool {
+	for {
+		err := to.Enqueue(task)
+		if err == nil {
+			return true
+		}
+		if errors.Is(err, karta.ErrSchedulerClosed) || s.closed.Load() {
+			return false
+		}
+		// ErrSchedulerFull 或其他瞬时错误：退避后重试，避免任务丢失
+		select {
+		case <-s.stopCh:
+			return false
+		case <-time.After(pumpRetryDelay):
+		}
 	}
 }
 
@@ -55,19 +124,24 @@ func (s *compositeScheduler) Done(task *karta.TaskEnvelope) {
 	s.schedulers[len(s.schedulers)-1].Done(task)
 }
 
+// Len 返回各级 Len 之和加上在途任务数，快照语义见 NewCompositeScheduler 的说明。
 func (s *compositeScheduler) Len() int {
-	total := 0
+	total := int(s.inflight.Load())
 	for _, sched := range s.schedulers {
 		total += sched.Len()
 	}
 	return total
 }
 
+// Shutdown 级联关闭所有子调度器并等待搬运泵退出，保证不泄漏 goroutine。
 func (s *compositeScheduler) Shutdown() {
 	if s.closed.CompareAndSwap(false, true) {
+		close(s.stopCh)
+		// 先关闭子调度器，使阻塞在 Dequeue 上的泵被唤醒退出
 		for _, sched := range s.schedulers {
 			sched.Shutdown()
 		}
+		s.wg.Wait()
 	}
 }
 

--- a/scheduler/composite_test.go
+++ b/scheduler/composite_test.go
@@ -2,6 +2,7 @@ package scheduler
 
 import (
 	"context"
+	"runtime"
 	"testing"
 	"time"
 
@@ -14,7 +15,7 @@ import (
 // 编译期接口断言
 var _ karta.Scheduler = NewCompositeScheduler()
 
-func TestComposite_EnqueueFirst(t *testing.T) {
+func TestComposite_TwoStageFlowThrough(t *testing.T) {
 	s1 := NewFIFOScheduler()
 	s2 := NewFIFOScheduler()
 	composite := NewCompositeScheduler(s1, s2)
@@ -23,19 +24,68 @@ func TestComposite_EnqueueFirst(t *testing.T) {
 	task := &karta.TaskEnvelope{Input: "composite-test"}
 	require.NoError(t, composite.Enqueue(task))
 
-	// Enqueue 写入第一个 scheduler
-	assert.Equal(t, 1, s1.Len())
-	assert.Equal(t, 0, s2.Len())
-	assert.Equal(t, 1, composite.Len())
+	// Enqueue 写入入口级，任务总数收敛为 1（位置取决于搬运泵进度）
+	assert.Eventually(t, func() bool {
+		return composite.Len() == 1
+	}, time.Second, 5*time.Millisecond)
 
-	// 从第一个 scheduler 可以取到
+	// 搬运泵应把任务从 s1 迁移到 s2，最终可从出口级取出
 	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
 	defer cancel()
 
-	env, err := s1.Dequeue(ctx)
+	env, err := composite.Dequeue(ctx)
 	require.NoError(t, err)
 	assert.Equal(t, "composite-test", env.Input)
-	s1.Done(env)
+	composite.Done(env)
+
+	assert.Eventually(t, func() bool {
+		return composite.Len() == 0
+	}, time.Second, 5*time.Millisecond)
+}
+
+func TestComposite_ThreeStageFlowThrough(t *testing.T) {
+	composite := NewCompositeScheduler(NewFIFOScheduler(), NewFIFOScheduler(), NewFIFOScheduler())
+	defer composite.Shutdown()
+
+	for i := 0; i < 3; i++ {
+		require.NoError(t, composite.Enqueue(&karta.TaskEnvelope{Input: i}))
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+
+	// 三级链路（两级搬运泵）下任务按序到达出口
+	for i := 0; i < 3; i++ {
+		env, err := composite.Dequeue(ctx)
+		require.NoError(t, err)
+		assert.Equal(t, i, env.Input)
+		composite.Done(env)
+	}
+	assert.Eventually(t, func() bool {
+		return composite.Len() == 0
+	}, time.Second, 5*time.Millisecond)
+}
+
+func TestComposite_PumpRetriesFullStage(t *testing.T) {
+	// 中间级容量极小：泵在下一级满时应退避重试而非丢弃任务
+	s1 := NewFIFOScheduler()
+	s2 := NewBoundedScheduler(1)
+	composite := NewCompositeScheduler(s1, s2)
+	defer composite.Shutdown()
+
+	require.NoError(t, composite.Enqueue(&karta.TaskEnvelope{Input: 1}))
+	require.NoError(t, composite.Enqueue(&karta.TaskEnvelope{Input: 2}))
+
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+
+	// 两个任务都应最终穿过容量为 1 的中间级，无一丢失
+	for i := 1; i <= 2; i++ {
+		env, err := composite.Dequeue(ctx)
+		require.NoError(t, err)
+		assert.Equal(t, i, env.Input)
+		composite.Done(env)
+	}
 }
 
 func TestComposite_DequeueFromLast(t *testing.T) {
@@ -80,6 +130,43 @@ func TestComposite_Shutdown(t *testing.T) {
 	assert.ErrorIs(t, err, karta.ErrSchedulerClosed)
 }
 
+// TestComposite_ShutdownStopsPumps 用放大法验证搬运泵无泄漏：
+//
+//	repeatedly 创建带 2 个泵的组合调度器再关闭，若泵泄漏，
+//
+// goroutine 数量会随轮次线性增长。Shutdown 内部已 wg.Wait()
+// 等待泵退出，此处提供可观察的回归证据。
+func TestComposite_ShutdownStopsPumps(t *testing.T) {
+	before := runtime.NumGoroutine()
+
+	const rounds = 20
+	for i := 0; i < rounds; i++ {
+		c := NewCompositeScheduler(NewFIFOScheduler(), NewFIFOScheduler(), NewFIFOScheduler())
+		require.NoError(t, c.Enqueue(&karta.TaskEnvelope{Input: i}))
+		c.Shutdown()
+	}
+
+	// 若泵泄漏，rounds 轮至少新增 2*rounds 个 goroutine；
+	// 给运行时瞬时 goroutine（GC 等）留出少量余量。
+	after := runtime.NumGoroutine()
+	assert.Less(t, after-before, rounds)
+}
+
+func TestComposite_DequeueAfterShutdown(t *testing.T) {
+	composite := NewCompositeScheduler(NewFIFOScheduler(), NewFIFOScheduler())
+	require.NoError(t, composite.Enqueue(&karta.TaskEnvelope{Input: "pending"}))
+
+	composite.Shutdown()
+
+	// Shutdown 后出口级已关闭：Dequeue 立即返回错误，不阻塞、不死锁
+	ctx, cancel := context.WithTimeout(context.Background(), 500*time.Millisecond)
+	defer cancel()
+
+	env, err := composite.Dequeue(ctx)
+	assert.Nil(t, env)
+	assert.ErrorIs(t, err, karta.ErrSchedulerClosed)
+}
+
 func TestComposite_Len(t *testing.T) {
 	s1 := NewFIFOScheduler()
 	s2 := NewFIFOScheduler()
@@ -90,7 +177,10 @@ func TestComposite_Len(t *testing.T) {
 	require.NoError(t, s1.Enqueue(&karta.TaskEnvelope{Input: 2}))
 	require.NoError(t, s2.Enqueue(&karta.TaskEnvelope{Input: 3}))
 
-	assert.Equal(t, 3, composite.Len())
+	// Len 为最终一致快照：任务跨级迁移的瞬间可能偏差 1，静置后收敛为 3
+	assert.Eventually(t, func() bool {
+		return composite.Len() == 3
+	}, time.Second, 5*time.Millisecond)
 }
 
 func TestComposite_Empty(t *testing.T) {

--- a/scheduler/delay.go
+++ b/scheduler/delay.go
@@ -84,7 +84,7 @@ func (s *delayScheduler) Dequeue(ctx context.Context) (*karta.TaskEnvelope, erro
 				backoff = maxBackoff
 			}
 		}
-		stopAndDrainTimer(timer)
+		// Go 1.23+ 保证 Reset 返回后不会收到旧定时值，直接重设即可
 		timer.Reset(backoff)
 	}
 }

--- a/scheduler/dlq.go
+++ b/scheduler/dlq.go
@@ -68,7 +68,7 @@ func (s *dlqScheduler) Enqueue(task *karta.TaskEnvelope) error {
 func (s *dlqScheduler) Dequeue(ctx context.Context) (*karta.TaskEnvelope, error) {
 	backoff := minBackoff
 	timer := time.NewTimer(backoff)
-	defer stopAndDrainTimer(timer)
+	defer timer.Stop()
 
 	for {
 		letter, err := s.queue.GetDead()
@@ -96,7 +96,7 @@ func (s *dlqScheduler) Dequeue(ctx context.Context) (*karta.TaskEnvelope, error)
 				backoff = maxBackoff
 			}
 		}
-		stopAndDrainTimer(timer)
+		// Go 1.23+ 保证 Reset 返回后不会收到旧定时值，直接重设即可
 		timer.Reset(backoff)
 	}
 }

--- a/scheduler/fifo.go
+++ b/scheduler/fifo.go
@@ -17,19 +17,6 @@ const (
 	maxBackoff = 500 * time.Millisecond
 )
 
-// stopAndDrainTimer 安全地停止 timer 并排空其 channel，
-// 使得后续的 timer.Reset 不会发生竞态。
-// 适用于所有 time.Timer（无论是否已触发）。
-func stopAndDrainTimer(timer *time.Timer) {
-	if !timer.Stop() {
-		// timer 已触发：排空 channel（若非 select 已消费则为空）
-		select {
-		case <-timer.C:
-		default:
-		}
-	}
-}
-
 // notifyChanCapacity 根据 CPU 数量计算 notify channel 容量，
 // 避免高吞吐下非阻塞发送丢通知；下限为 4。
 func notifyChanCapacity() int {
@@ -111,8 +98,7 @@ func (s *fifoScheduler) Dequeue(ctx context.Context) (*karta.TaskEnvelope, error
 				backoff = maxBackoff
 			}
 		}
-		// 安全重设：先 Stop+drain（处理所有分支），再 Reset
-		stopAndDrainTimer(timer)
+		// Go 1.23+ 保证 Reset 返回后不会收到旧定时值，直接重设即可
 		timer.Reset(backoff)
 	}
 }

--- a/scheduler/lease.go
+++ b/scheduler/lease.go
@@ -14,31 +14,67 @@ import (
 // 编译期接口检查：确保 leaseScheduler 实现 Scheduler 接口
 var _ karta.Scheduler = (*leaseScheduler)(nil)
 
+// leaseEntry 记录一次 Dequeue 交付的租约信息。
+// leaseID 是底层队列的租约键，用于 Ack；owner 指向底层队列持有的原始
+// 任务指针，用于在任务完成时清理 owners 正向索引。
+type leaseEntry struct {
+	leaseID string
+	owner   *karta.TaskEnvelope
+}
+
 // leaseScheduler 将 workqueue.LeasedQueue 适配为 karta.Scheduler 接口。
 //
 // Dequeue 通过 GetWithLease 获取任务并绑定租约；
 // Done 通过 Ack 释放租约确认处理完成。
-// 租约超时的任务由底层队列自动 Nack 并重新入队。
+// 租约超时的任务由底层队列自动重新入队。
+//
+// 所有权契约：Dequeue 总是返回 TaskEnvelope 的浅拷贝，而非底层队列持有的
+// 原始指针。租约过期触发重投递时，先后两个消费者拿到的是不同的指针，
+// 保证"两个消费者不得同时持有同一 *TaskEnvelope"。底层租约以 leaseID
+// 为键（与投递出去的对象指针无关），因此 Done(拷贝) 仍能正确 Ack
+// 原始对象的租约；已过期的租约 Ack 失败时被静默忽略。
 type leaseScheduler struct {
 	queue        workqueue.LeasedQueue
 	closed       atomic.Bool
 	leaseTimeout time.Duration
-	leases       sync.Map // map[*karta.TaskEnvelope]string (leaseID)
-	notify       chan struct{}
-	doneCh       chan struct{}
+	// leases 以交付给消费者的拷贝指针为键，反查租约信息，供 Done 使用。
+	leases sync.Map // map[*karta.TaskEnvelope]*leaseEntry
+	// owners 以底层原始任务指针为键，记录当前交付在外的拷贝，
+	// 用于重投递时清理上一份未完成的 leases 记录，避免映射泄漏。
+	owners sync.Map // map[*karta.TaskEnvelope]*karta.TaskEnvelope
+	notify chan struct{}
+	doneCh chan struct{}
 }
 
 // NewLeaseScheduler 创建基于 workqueue.LeasedQueue 的租约调度器。
 // leaseTimeout 指定每次 Dequeue 获取的租约超时时间。
 func NewLeaseScheduler(leaseTimeout time.Duration) karta.Scheduler {
 	cfg := workqueue.NewLeasedQueueConfig().
-		WithLeaseDuration(leaseTimeout)
+		WithLeaseDuration(leaseTimeout).
+		WithScanInterval(leaseScanInterval(leaseTimeout))
 	return &leaseScheduler{
 		queue:        workqueue.NewLeasedQueue(cfg),
 		leaseTimeout: leaseTimeout,
 		notify:       make(chan struct{}, notifyChanCapacity()),
 		doneCh:       make(chan struct{}),
 	}
+}
+
+// leaseScanInterval 计算过期租约的扫描间隔：取租约时长的 1/4，
+// 并限定在 [1ms, 100ms] 区间，兼顾重投递的及时性与扫描开销。
+func leaseScanInterval(leaseTimeout time.Duration) time.Duration {
+	if leaseTimeout <= 0 {
+		// 与 workqueue.LeasedQueueConfig 的默认租约时长保持一致
+		leaseTimeout = 30 * time.Second
+	}
+	interval := leaseTimeout / 4
+	if interval < time.Millisecond {
+		interval = time.Millisecond
+	}
+	if interval > 100*time.Millisecond {
+		interval = 100 * time.Millisecond
+	}
+	return interval
 }
 
 func (s *leaseScheduler) Enqueue(task *karta.TaskEnvelope) error {
@@ -65,14 +101,13 @@ func (s *leaseScheduler) Enqueue(task *karta.TaskEnvelope) error {
 func (s *leaseScheduler) Dequeue(ctx context.Context) (*karta.TaskEnvelope, error) {
 	backoff := minBackoff
 	timer := time.NewTimer(backoff)
-	defer stopAndDrainTimer(timer)
+	defer timer.Stop()
 
 	for {
 		val, leaseID, err := s.queue.GetWithLease(s.leaseTimeout)
 		if err == nil {
-			if env, ok := val.(*karta.TaskEnvelope); ok {
-				s.leases.Store(env, leaseID)
-				return env, nil
+			if orig, ok := val.(*karta.TaskEnvelope); ok {
+				return s.deliver(orig, leaseID), nil
 			}
 			// 类型不匹配时释放租约
 			_ = s.queue.Ack(leaseID)
@@ -94,18 +129,36 @@ func (s *leaseScheduler) Dequeue(ctx context.Context) (*karta.TaskEnvelope, erro
 				backoff = maxBackoff
 			}
 		}
-		stopAndDrainTimer(timer)
+		// Go 1.23+ 保证 Reset 返回后不会收到旧定时值，直接重设即可
 		timer.Reset(backoff)
 	}
 }
 
-// Done 释放与任务关联的租约（Ack）。
-// 如果租约已过期或不存在，静默忽略（底层会重新入队）。
-func (s *leaseScheduler) Done(task *karta.TaskEnvelope) {
-	if val, ok := s.leases.LoadAndDelete(task); ok {
-		leaseID := val.(string)
-		_ = s.queue.Ack(leaseID)
+// deliver 基于底层原始任务生成一个交付给消费者的浅拷贝并登记租约。
+// 重投递场景下（同一原始指针再次出队），用新拷贝替换 owners 索引，
+// 并清理上一份未完成拷贝在 leases 中的记录，防止映射泄漏。
+func (s *leaseScheduler) deliver(orig *karta.TaskEnvelope, leaseID string) *karta.TaskEnvelope {
+	copied := *orig
+	delivered := &copied
+	if prev, loaded := s.owners.Swap(orig, delivered); loaded {
+		s.leases.Delete(prev)
 	}
+	s.leases.Store(delivered, &leaseEntry{leaseID: leaseID, owner: orig})
+	return delivered
+}
+
+// Done 释放与任务关联的租约（Ack）。
+// task 应为 Dequeue 返回的拷贝。如果租约已过期或不存在，静默忽略
+// （过期任务已由底层重新入队）。
+func (s *leaseScheduler) Done(task *karta.TaskEnvelope) {
+	val, ok := s.leases.LoadAndDelete(task)
+	if !ok {
+		return
+	}
+	entry := val.(*leaseEntry)
+	// 仅当正向索引仍指向当前拷贝时才清理，避免误删重投递后的新拷贝记录
+	s.owners.CompareAndDelete(entry.owner, task)
+	_ = s.queue.Ack(entry.leaseID)
 }
 
 func (s *leaseScheduler) Len() int {

--- a/scheduler/lease_test.go
+++ b/scheduler/lease_test.go
@@ -96,6 +96,71 @@ func TestLease_MultipleTasks(t *testing.T) {
 	}
 }
 
+// TestLease_RedeliveryOwnership 验证租约过期重投递的所有权契约：
+// 第一个消费者持有任务但不 Done，租约过期后任务被重新投递，
+// 第二个消费者拿到的必须是不同的 *TaskEnvelope（浅拷贝），
+// 且两者的 Done 互不干扰。
+func TestLease_RedeliveryOwnership(t *testing.T) {
+	s := NewLeaseScheduler(20 * time.Millisecond)
+	defer s.Shutdown()
+
+	task := &karta.TaskEnvelope{Input: "lease-redeliver"}
+	require.NoError(t, s.Enqueue(task))
+
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+
+	// 消费者 A 取走任务但不 Done，等待租约过期触发重投递
+	envA, err := s.Dequeue(ctx)
+	require.NoError(t, err)
+	assert.Equal(t, "lease-redeliver", envA.Input)
+
+	time.Sleep(30 * time.Millisecond)
+
+	// 消费者 B 拿到重投递的任务
+	envB, err := s.Dequeue(ctx)
+	require.NoError(t, err)
+	assert.Equal(t, "lease-redeliver", envB.Input)
+
+	// 拷贝交付：两个消费者不得持有同一指针
+	assert.NotSame(t, envA, envB)
+
+	// A、B 各自安全完成：A 的租约已过期（Ack 失败被静默忽略），
+	// B 的 Done 通过拷贝找回 leaseID，正确 Ack 底层对原对象的租约
+	s.Done(envA)
+	s.Done(envB)
+
+	// B 已完成确认：任务不应再次被投递出来
+	shortCtx, shortCancel := context.WithTimeout(context.Background(), 100*time.Millisecond)
+	defer shortCancel()
+	envC, err := s.Dequeue(shortCtx)
+	assert.Nil(t, envC)
+	assert.Error(t, err)
+}
+
+// TestLease_DoneCopyAcksUnderlyingLease 验证正常路径下 Done(拷贝)
+// 能正确 Ack 底层租约：完成确认后的任务不会被重投递。
+func TestLease_DoneCopyAcksUnderlyingLease(t *testing.T) {
+	s := NewLeaseScheduler(20 * time.Millisecond)
+	defer s.Shutdown()
+
+	require.NoError(t, s.Enqueue(&karta.TaskEnvelope{Input: "ack-check"}))
+
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+
+	env, err := s.Dequeue(ctx)
+	require.NoError(t, err)
+	s.Done(env)
+
+	// 等待超过租约时长：若 Ack 未生效，任务会被当作过期租约重新投递
+	idleCtx, idleCancel := context.WithTimeout(context.Background(), 100*time.Millisecond)
+	defer idleCancel()
+	env2, err := s.Dequeue(idleCtx)
+	assert.Nil(t, env2)
+	assert.Error(t, err)
+}
+
 // BenchmarkLeaseScheduler_EnqueueDequeue 测量 Lease 调度器在并发场景下
 // Enqueue + Dequeue 的吞吐（单 goroutine 循环：入队后立即出队）。
 func BenchmarkLeaseScheduler_EnqueueDequeue(b *testing.B) {

--- a/scheduler/priority.go
+++ b/scheduler/priority.go
@@ -85,7 +85,7 @@ func (s *priorityScheduler) Dequeue(ctx context.Context) (*karta.TaskEnvelope, e
 				backoff = maxBackoff
 			}
 		}
-		stopAndDrainTimer(timer)
+		// Go 1.23+ 保证 Reset 返回后不会收到旧定时值，直接重设即可
 		timer.Reset(backoff)
 	}
 }

--- a/scheduler/ratelimiting.go
+++ b/scheduler/ratelimiting.go
@@ -69,7 +69,7 @@ func (s *rateLimitingScheduler) Enqueue(task *karta.TaskEnvelope) error {
 func (s *rateLimitingScheduler) Dequeue(ctx context.Context) (*karta.TaskEnvelope, error) {
 	backoff := minBackoff
 	timer := time.NewTimer(backoff)
-	defer stopAndDrainTimer(timer)
+	defer timer.Stop()
 
 	for {
 		val, err := s.queue.Get()
@@ -95,7 +95,7 @@ func (s *rateLimitingScheduler) Dequeue(ctx context.Context) (*karta.TaskEnvelop
 				backoff = maxBackoff
 			}
 		}
-		stopAndDrainTimer(timer)
+		// Go 1.23+ 保证 Reset 返回后不会收到旧定时值，直接重设即可
 		timer.Reset(backoff)
 	}
 }

--- a/scheduler/retry.go
+++ b/scheduler/retry.go
@@ -17,6 +17,9 @@ var _ karta.Scheduler = (*retryScheduler)(nil)
 // retryScheduler 将 workqueue.RetryQueue 适配为 karta.Scheduler 接口。
 //
 // Done 标记任务成功完成并清除重试计数。
+// Enqueue 成功时会清除该指针遗留的重试计数：重试计数以指针为键，
+// 根包 TaskEnvelope 池复用指针后，旧任务的计数会串到新任务，
+// 因此每次新入队都视为新任务生命周期的开始。
 // 如需重试，通过类型断言访问 Retry 方法：
 //
 //	rs := sched.(*retryScheduler)  // 或使用接口断言
@@ -57,6 +60,13 @@ func (s *retryScheduler) Enqueue(task *karta.TaskEnvelope) error {
 		}
 		return err
 	}
+	// 指针复用防护：重试计数以 envelope 指针为键（见 retryTaskKeyFunc），
+	// 根包 TaskEnvelope 池归还并复用指针后，旧任务的计数会串到新任务。
+	// 入队成功即代表该指针开启新的任务生命周期，必须在此清除遗留计数，
+	// 保证记录在指针归还 pool 前已清零。
+	// （重试耗尽路径无需处理：workqueue.RetryQueue 在 ErrRetryExhausted
+	// 时已内部重置计数。）
+	s.queue.Forget(task)
 	select {
 	case s.notify <- struct{}{}:
 	default:
@@ -67,7 +77,7 @@ func (s *retryScheduler) Enqueue(task *karta.TaskEnvelope) error {
 func (s *retryScheduler) Dequeue(ctx context.Context) (*karta.TaskEnvelope, error) {
 	backoff := minBackoff
 	timer := time.NewTimer(backoff)
-	defer stopAndDrainTimer(timer)
+	defer timer.Stop()
 
 	for {
 		val, err := s.queue.Get()
@@ -93,7 +103,7 @@ func (s *retryScheduler) Dequeue(ctx context.Context) (*karta.TaskEnvelope, erro
 				backoff = maxBackoff
 			}
 		}
-		stopAndDrainTimer(timer)
+		// Go 1.23+ 保证 Reset 返回后不会收到旧定时值，直接重设即可
 		timer.Reset(backoff)
 	}
 }

--- a/scheduler/retry_test.go
+++ b/scheduler/retry_test.go
@@ -102,6 +102,47 @@ func TestRetry_RetryAndRequeue(t *testing.T) {
 	s.Done(env2)
 }
 
+// TestRetry_ReusePointerResetsCount 验证指针复用场景下的计数清零：
+// 根包 TaskEnvelope 池会把同一指针用于新任务，旧任务遗留的重试计数
+// 不得串到新任务。同一指针再次 Enqueue 时计数必须从零开始。
+func TestRetry_ReusePointerResetsCount(t *testing.T) {
+	policy := workqueue.NewExponentialRetryPolicy(10*time.Millisecond, 50*time.Millisecond, -1)
+	s := NewRetryScheduler(policy)
+	defer s.Shutdown()
+
+	type retryable interface {
+		Retry(task *karta.TaskEnvelope, reason error) error
+		NumRequeues(task *karta.TaskEnvelope) int
+	}
+	rs, ok := s.(retryable)
+	require.True(t, ok)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+
+	task := &karta.TaskEnvelope{Input: "first-lifetime"}
+	require.NoError(t, s.Enqueue(task))
+
+	// 第一个任务生命周期：出队并重试一次，累积计数
+	env, err := s.Dequeue(ctx)
+	require.NoError(t, err)
+	require.NoError(t, rs.Retry(env, errors.New("transient")))
+	assert.Equal(t, 1, rs.NumRequeues(task))
+
+	// 出队重试后的任务但不 Done，模拟任务未正常终结、指针被归还池复用
+	env2, err := s.Dequeue(ctx)
+	require.NoError(t, err)
+	require.Equal(t, task, env2)
+
+	// 同一指针承载新任务：再次入队必须清除遗留计数
+	task.Input = "second-lifetime"
+	require.NoError(t, s.Enqueue(task))
+	assert.Equal(t, 0, rs.NumRequeues(task))
+
+	// 清理在途任务，避免影响后续断言
+	s.Done(env2)
+}
+
 func TestRetry_MaxRetries_Respected(t *testing.T) {
 	// maxRetries=1: 只允许重试 1 次
 	policy := workqueue.NewExponentialRetryPolicy(10*time.Millisecond, 50*time.Millisecond, 1)

--- a/scheduler/timer.go
+++ b/scheduler/timer.go
@@ -70,7 +70,7 @@ func (s *timerScheduler) Enqueue(task *karta.TaskEnvelope) error {
 func (s *timerScheduler) Dequeue(ctx context.Context) (*karta.TaskEnvelope, error) {
 	backoff := minBackoff
 	timer := time.NewTimer(backoff)
-	defer stopAndDrainTimer(timer)
+	defer timer.Stop()
 
 	for {
 		val, err := s.queue.Get()
@@ -96,7 +96,7 @@ func (s *timerScheduler) Dequeue(ctx context.Context) (*karta.TaskEnvelope, erro
 				backoff = maxBackoff
 			}
 		}
-		stopAndDrainTimer(timer)
+		// Go 1.23+ 保证 Reset 返回后不会收到旧定时值，直接重设即可
 		timer.Reset(backoff)
 	}
 }

--- a/to_middleware.go
+++ b/to_middleware.go
@@ -1,14 +1,21 @@
 package karta
 
+import "fmt"
+
 // toMiddlewareSlice 将 []any 转换为 []Middleware[In, Out]
 // Phase 2 T2.7: 运行时类型断言，绕过 Go 泛型 struct field 限制
+//
+// 类型不匹配视为配置错误，直接 panic（fail-fast）：
+// 静默丢弃会导致 middleware 未生效且难以排查
 func toMiddlewareSlice[In, Out any](raw []any) []Middleware[In, Out] {
 	mws := make([]Middleware[In, Out], 0, len(raw))
 	for _, v := range raw {
-		if mw, ok := v.(Middleware[In, Out]); ok {
-			mws = append(mws, mw)
+		mw, ok := v.(Middleware[In, Out])
+		if !ok {
+			var expected Middleware[In, Out]
+			panic(fmt.Sprintf("karta: middleware type mismatch: expected %T, got %T", expected, v))
 		}
-		// 类型不匹配的 middleware 被静默忽略
+		mws = append(mws, mw)
 	}
 	return mws
 }

--- a/to_middleware_test.go
+++ b/to_middleware_test.go
@@ -1,0 +1,67 @@
+package karta
+
+import (
+	"context"
+	"sync/atomic"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestToMiddlewareSlice_TypeMismatch_Panics — P1 #4:
+// 类型不匹配的 middleware 视为配置错误，fail-fast panic，message 含期望与实际类型
+func TestToMiddlewareSlice_TypeMismatch_Panics(t *testing.T) {
+	matched := countMiddleware[int, int](nil)
+	mismatched := countMiddleware[int, string](nil) // Middleware[int, string] ← 类型不匹配
+
+	require.Panics(t, func() {
+		toMiddlewareSlice[int, int]([]any{matched, mismatched})
+	}, "类型不匹配的 middleware 应 panic 而非静默丢弃")
+
+	// panic message 必须包含期望类型与实际类型（%T 输出格式）
+	defer func() {
+		msg, ok := recover().(string)
+		require.True(t, ok)
+		assert.Contains(t, msg, "Middleware[int,int]")    // 期望类型
+		assert.Contains(t, msg, "Middleware[int,string]") // 实际类型
+	}()
+	toMiddlewareSlice[int, int]([]any{mismatched})
+}
+
+// TestNewGroup_MiddlewareTypeMismatch_Panics — NewGroup 挂类型不匹配的 middleware 应 panic
+func TestNewGroup_MiddlewareTypeMismatch_Panics(t *testing.T) {
+	handler := func(ctx context.Context, v int) (int, error) { return v, nil }
+	mismatched := countMiddleware[string, string](nil)
+
+	require.Panics(t, func() {
+		NewGroup[int, int](handler, WithGroupMiddleware(mismatched))
+	})
+}
+
+// TestNewPipeline_MiddlewareTypeMismatch_Panics — NewPipeline 挂类型不匹配的 middleware
+// 应在构造时（executor 启动前）panic，而非在 executor goroutine 内崩溃
+func TestNewPipeline_MiddlewareTypeMismatch_Panics(t *testing.T) {
+	handler := func(ctx context.Context, v int) (int, error) { return v, nil }
+	mismatched := countMiddleware[string, string](nil)
+
+	require.Panics(t, func() {
+		NewPipeline[int, int](handler, NewSimpleScheduler(16), WithPipelineMiddleware(mismatched))
+	})
+}
+
+// TestNewPipeline_MiddlewareMatched_Works — 类型匹配的 middleware 正常使用不受影响
+func TestNewPipeline_MiddlewareMatched_Works(t *testing.T) {
+	var counter atomic.Int64
+	handler := func(ctx context.Context, v int) (int, error) { return v * 2, nil }
+	p := NewPipeline[int, int](handler, NewSimpleScheduler(16),
+		WithPipelineMiddleware(countMiddleware[int, int](&counter)))
+	defer p.Stop()
+
+	f, err := p.Submit(context.Background(), 21)
+	require.NoError(t, err)
+	res := f.Get(context.Background())
+	require.NoError(t, res.Err)
+	assert.Equal(t, 42, res.Value)
+	assert.Equal(t, int64(1), counter.Load(), "middleware 应恰好执行一次")
+}


### PR DESCRIPTION
feat: upgrade to Go 1.23, fix concurrency defects, and optimize hot paths

Go 1.23 upgrade:
- go.mod: go 1.21 -> 1.23; CI matrix 1.19-1.22 -> 1.23/1.24/1.25, run go vet + go test -race, fix stale ./test/... path; os matrix uses ubuntu-latest/macos-15/windows-latest
- Move POSIX signal tests to lifecycle_unix_test.go (//go:build !windows) so the test binary compiles on Windows
- Apply Go 1.23 timer semantics: remove Stop+drain boilerplate around Reset in the pipeline scan loop and all scheduler backoff loops; delete stopAndDrainTimer helper

Correctness fixes (from full-tree audit):
- Fix lease re-delivery handing the same *TaskEnvelope to two executors: Dequeue now delivers shallow copies tracked by dual lease/owner indexes, eliminating double pool puts and cross-task data corruption
- Clear stale retry counts after successful enqueue (queue.Forget) to keep pooled envelope pointers from inheriting old retry state
- Close the Submit-vs-Stop race: closed check, pending insert and wg.Add now share one pendingMu critical section on every path
- Resolve with UserCtx.Err() instead of executing handlers submitted with an already-cancelled context
- Fix SubmitAfter double delay on delay-aware schedulers by clearing envelope.Delay before enqueue
- Rework Group concurrent path panic handling to per-item recover so every input yields exactly one Result (no silent zero-value successes)
- Replace Group busy-spin wait with bounded spinning followed by a blocking wait on a completion channel
- Executor nil-future branch now only acks the scheduler and never returns the envelope to the pool (exactly-once put invariant)
- Fail fast at NewGroup/NewPipeline when middleware type parameters do not match, instead of silently dropping it
- Implement CompositeScheduler inter-stage pump with graceful shutdown (previously tasks enqueued on stage 0 never reached the dequeue stage)
- Bounded scheduler now returns ErrSchedulerFull when full instead of blocking indefinitely, per the Scheduler interface contract
- Metrics middleware reuses already-registered Prometheus collectors and panics on other registration errors instead of dropping metrics silently
- Use a CAS loop to reserve worker slots in trySpawnWorker and spawn workers after delayed enqueues as well
- Remove dead doneChanPool; NewResolvedFuture rejects later Resolve calls

Performance:
- Merge the Future resolved/claimed atomic.Bool pair into a single atomic.Uint32 state word, cutting NewResolvedFuture to one atomic store
- Submit/SubmitAfter now use the per-executor pre-wrapped default handler instead of re-chaining middleware per task
- Add benchmarks: GroupMap_LargeBatch, PipelineSubmit_Parallel, FutureThen

Docs:
- README: Go 1.23 requirement, refreshed benchmark table with measured values (i5-12400F / Windows), bounded scheduler caveat
- MIGRATION.md: Go version references 1.21 -> 1.23
- Document composite at-least-once delivery under downstream back-pressure and the bounded scheduler's residual blocking semantics
- Add AGENTS.md with benchmark sampling discipline

Verified: gofmt/go vet/go build clean; go test -race -count=2 ./... all green; same-session benchstat A/B shows 4/7 common benchmarks improved 4.6%-5.5% with zero B/op or allocs/op regressions.